### PR TITLE
chore [PIDM-1954]: Improve Node app performance

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,31 @@ The project is composed of two processes:
 | **Java function** (Azure Functions HTTP trigger) | `src/` | Java 17 | Public REST entry point. Receives the multipart request, forwards it to the Node sidecar, then converts the returned PDF to **PDF/A-2a** with Spire.PDF and (optionally) zips the result. |
 | **Node.js sidecar** | `node/` | Node.js ≥ 24 | Renders the Handlebars template (with i18n support), launches a headless Chromium via Puppeteer and produces a plain PDF. |
 
+
+### Deployment topology
+
+Two components are deployed on **two distinct Azure App Service plans**, scaled independently.
+
+```mermaid
+flowchart LR
+    Client([Client])
+
+    subgraph AzJava["Azure App Service — Java plan"]
+        Java["Java function<br/>Azure Functions<br/>Spire.PDF (PDF → PDF/A-2a)"]
+    end
+
+    subgraph AzNode["Azure App Service — Node plan"]
+        Node["Node sidecar<br/>Puppeteer + Chrome"]
+    end
+
+    Client -- "POST /generate-pdf<br/>multipart" --> Java
+    Java -- "POST /generate-pdf<br/>HTTP" --> Node
+    Node -- "application/pdf" --> Java
+    Java -- "application/pdf<br/>or application/zip" --> Client
+```
+
+### Request flow
+
 ```mermaid
 sequenceDiagram
     autonumber

--- a/README.md
+++ b/README.md
@@ -1,171 +1,296 @@
-# pagoPA Generate PDF function
+# pagoPA PDF Engine
 
 [![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=pagopa_pagopa-pdf-engine&metric=alert_status)](https://sonarcloud.io/dashboard?id=pagopa_pagopa-pdf-engine)
 
-Java Azure Function that exposes REST API to generate a PDFA/2a document based on the provided data and HTML template.
+Service that exposes a REST API to generate a **PDF/A-2a** document starting from a JSON payload and a Handlebars HTML template.
+
+The project is composed of two processes:
+
+| Component | Path | Runtime | Role |
+|---|---|---|---|
+| **Java function** (Azure Functions HTTP trigger) | `src/` | Java 17 | Public REST entry point. Receives the multipart request, forwards it to the Node sidecar, then converts the returned PDF to **PDF/A-2a** with Spire.PDF and (optionally) zips the result. |
+| **Node.js sidecar** | `node/` | Node.js ≥ 24 | Renders the Handlebars template (with i18n support), launches a headless Chromium via Puppeteer and produces a plain PDF. |
+
+```mermaid
+sequenceDiagram
+    autonumber
+    actor Client
+    participant Java as Java function<br/>(Azure Functions)
+    participant Node as Node sidecar<br/>(Puppeteer + Chrome)
+
+    Client->>Java: POST /generate-pdf<br/>(multipart: template.zip + data JSON)
+    Java->>Java: Parse multipart<br/>create temp working dir
+    Java->>Node: POST /generate-pdf<br/>(template.zip + data)
+    Node->>Node: Unzip template<br/>Handlebars compile + render<br/>Launch headless Chrome<br/>Generate PDF
+    Node-->>Java: 200 OK (application/pdf)
+    Java->>Java: Convert PDF → PDF/A-2a (Spire.PDF)<br/>optional zip
+    Java-->>Client: 200 OK (application/pdf or application/zip)
+```
 
 ---
+
 ## Summary 📖
 
-- [API Documentation 📖](#api-documentation-)
+- [API Documentation](#api-documentation-)
 - [Technology Stack](#technology-stack)
-- [Start Project Locally 🚀](#start-project-locally-)
-  * [Run locally with Docker](#run-locally-with-docker)
-      + [Prerequisites](#prerequisites)
-      + [Run docker container](#run-docker-container)
-  * [Run locally with Maven](#run-locally-with-maven)
-      + [Prerequisites](#prerequisites-1)
-      + [Run the project](#run-the-project)
-  * [Test](#test)
-- [Develop Locally 💻](#develop-locally-)
-  * [Prerequisites](#prerequisites-2)
-  * [Testing 🧪](#testing-)
-    + [Unit testing](#unit-testing)
-    + [Integration testing](#integration-testing)
-    + [Performance testing](#performance-testing)
+- [Architecture & request flow](#architecture--request-flow)
+- [Chrome version pinning](#chrome-version-pinning-)
+- [Configuration](#configuration)
+- [Run locally](#run-locally-)
+  * [With Docker (recommended)](#with-docker-recommended)
+  * [Java function with Maven](#java-function-with-maven)
+  * [Node sidecar standalone](#node-sidecar-standalone)
+- [Testing 🧪](#testing-)
 - [Contributors 👥](#contributors-)
-  * [Maintainers](#maintainers)
 
 ---
+
 ## API Documentation 📖
-See the [OpenApi 3 here.](https://editor.swagger.io/?url=https://raw.githubusercontent.com/pagopa/pagopa-pdf-engine/main/openapi/openapi.json)
+
+OpenAPI 3 specs:
+
+- Public API (Java function): [`openapi/openapi.json`](./openapi/openapi.json)
+- Internal Node sidecar: [`openapi/openapi_node.json`](./openapi/openapi_node.json)
+- Monitor / info endpoints: [`openapi/openapi-pdf-engine-monitor.json`](./openapi/openapi-pdf-engine-monitor.json), [`openapi/openapi-node-monitor.json`](./openapi/openapi-node-monitor.json)
+
+Quick view: [OpenApi 3 here.](https://editor.swagger.io/?url=https://raw.githubusercontent.com/pagopa/pagopa-pdf-engine/main/openapi/openapi.json)
 
 ---
 
 ## Technology Stack
-- Java 11
-- IText7
-- Handlebars
-- Zip4j
+
+**Java function**
+- Java 17
+- Azure Functions Java library 1.4.2
+- Apache HttpClient 4.5 (to call the Node sidecar)
+- Spire.PDF Free 9.13 — PDF → PDF/A-2a conversion
+- Zip4j 2.11
+- Logback + ECS encoder, Application Insights 3.7
+
+**Node.js sidecar**
+- Node.js ≥ 24
+- Express 4 + Multer (multipart)
+- Handlebars 4.7 + `handlebars-i18n` + `i18next` (multilingual templates)
+- Puppeteer **25.0.4** with **Chrome 127.0.6533.88** (see [Chrome version pinning](#chrome-version-pinning-))
+- `adm-zip`, `fs-extra`, `bwip-js`, `qrcode-svg`
+- `applicationinsights` SDK
 
 ---
 
-## Start Project Locally 🚀
+## Architecture & request flow
 
-### Run locally with Docker
+1. The client `POST`s a multipart request to `/generate-pdf` on the **Java function**.
+2. The Java function parses the body, creates a temp working directory and forwards the JSON `data` + the `template` zip to the **Node sidecar** via HTTP `POST`.
+3. The Node sidecar:
+   - extracts the zip into a temp directory;
+   - reads `template.html`, compiles it with Handlebars (an LRU cache keyed on the SHA-1 of the source avoids recompiling the same template on every request — `TEMPLATE_CACHE_MAX = 32`);
+   - renders the HTML, opens it in a Chromium page via a `file:` URL;
+   - waits for layout stability (`waitForRender` polls `body.scrollHeight` + DOM size until stable);
+   - calls `page.pdf(...)` and returns the binary PDF.
+4. The Java function converts the received PDF into **PDF/A-2a**.
+5. If `generateZipped=true` the result is zipped, otherwise the raw PDF is returned with `Content-Type: application/pdf`.
 
-#### Prerequisites
-- docker
+> ⚠️ The HTML template inside the zip **must** be named `template.html` (the Node sidecar reads exactly that file).
 
-#### Run docker container
-`docker build -t pagopa-pdf-engine .`
+---
 
-`docker run -p 7071:80 pagopa-pdf-engine`
+## Chrome version pinning 📌
 
-### Run locally with Maven
+The Node sidecar **does not** use the Chrome version that `puppeteer install` would download automatically. Instead, [`node/Dockerfile`](./node/Dockerfile) explicitly installs **Chrome 127.0.6533.88** and tells Puppeteer to use it via `PUPPETEER_EXECUTABLE_PATH`.
 
-#### Prerequisites
-- maven
+### Why
 
-#### Run the project
-`mvn clean package`
+During the multilingual rollout we upgraded Puppeteer from `22.x` to `24.x` / `25.x`. With the newer Puppeteer, `yarn install` started bringing in much more recent Chrome (Chrome for Testing) builds, and PDF generation throughput dropped from **~4.94 req/s** (baseline `2.10.23`) to **~3.72 req/s** under our standard k6 load test, even after isolating every other variable (Node version, code changes, template, infra).
 
-`mvn azure-functions:run`
+Bisecting Puppeteer + Chrome combinations against the baseline showed the regression lives in the bundled **Chromium PDF pipeline** (`Page.printToPDF` / layout under load), not in Puppeteer's JS layer. Forcing Puppeteer 25 to drive **Chrome 127** (the last build bundled with Puppeteer 22.x) restored the baseline (**~5.00 req/s**) without rolling back any other change.
 
-### Test
+Puppeteer 25 talks to Chrome via the DevTools Protocol, which is backward compatible for the commands we use (`Page.navigate`, `Page.printToPDF`, …), so pairing it with an older Chrome is fully supported.
+
+### How
+
+In [`node/Dockerfile`](./node/Dockerfile):
+
+```dockerfile
+# 1) Skip Puppeteer's automatic Chrome download at install time
+ENV PUPPETEER_SKIP_DOWNLOAD=true
+ARG PINNED_CHROME_VERSION=127.0.6533.88
+
+# 2) Install the pinned Chrome explicitly into PUPPETEER_CACHE_DIR
+RUN npx --yes @puppeteer/browsers install chrome@${PINNED_CHROME_VERSION} \
+        --path ${PUPPETEER_CACHE_DIR}
+
+# 3) At runtime, point Puppeteer to that exact binary
+ENV PUPPETEER_EXECUTABLE_PATH=/usr/src/app/.cache/puppeteer/chrome/linux-${PINNED_CHROME_VERSION}/chrome-linux64/chrome
 ```
+
+### Maintenance
+
+- To try a different Chrome build, override the build arg:
+  `docker build --build-arg PINNED_CHROME_VERSION=128.0.6613.137 -t pdf-engine-node ./node`
+- Available builds: <https://googlechromelabs.github.io/chrome-for-testing/>
+- The pin should be re-evaluated every 3–6 months: if a newer Chrome stops exhibiting the PDF regression, remove the pin and let Puppeteer manage the browser.
+- If you bump Puppeteer, also bump the headless-shell native dependencies (`apt-get install` list in the Dockerfile) to whatever Puppeteer's troubleshooting docs require.
+
+---
+
+## Configuration
+
+### Java function
+
+| Variable | Default | Description |
+|---|---|---|
+| `PDF_ENGINE_NODE_GENERATE_ENDPOINT` | `http://localhost:3000/generate-pdf` | URL of the Node sidecar `generate-pdf` endpoint |
+| `PDF_ENGINE_NODE_INFO_ENDPOINT` | `http://localhost:3000/info` | URL of the Node sidecar `info` endpoint |
+| `PDF_ENGINE_NODE_SUBKEY` | `NO_SUB_KEY` | Value of the `Ocp-Apim-Subscription-Key` header sent to the sidecar |
+| `WORKING_DIRECTORY_PATH` | `""` (current dir) | Base directory for per-request temp folders |
+| `APPLICATIONINSIGHTS_CONNECTION_STRING` | — | App Insights connection string for telemetry |
+
+### Node sidecar
+
+| Variable | Default | Description |
+|---|---|---|
+| `PUPPETEER_EXECUTABLE_PATH` | set by the Dockerfile to the pinned Chrome | Override the Chrome binary used by Puppeteer |
+| `PUPPETEER_CACHE_DIR` | `/usr/src/app/.cache/puppeteer` | Where Puppeteer looks for installed browsers |
+| `PUPPETEER_SKIP_DOWNLOAD` | `true` in the image | Skip automatic Chrome download during `yarn install` |
+| `PDF_CONCURRENCY` | _unset_ (unlimited) | Optional per-process cap on concurrent `generatePdf` invocations. Set to e.g. `2 × vCPU` in production to protect Chromium; leave unset for k6 perf tests to avoid Little's-law artefacts. |
+| `CHECK_SIZE_INTERVAL` | `100` (ms) | Polling interval used by `waitForRender` |
+| `MIN_STABLE_SIZE_ITERATIONS` | `3` | Number of stable polls before the page is considered fully rendered |
+| `PERF_LOG` | `true` | Emit fine-grained per-phase timings as App Insights `PDF_ENGINE_NODE_PERF_*` custom events |
+| `APPLICATIONINSIGHTS_CONNECTION_STRING` | — | App Insights connection string for telemetry |
+
+### Template zip layout
+
+The `template` form field must be a zip containing **at least**:
+
+```
+template.html        # main Handlebars template (mandatory)
+style.css            # CSS file referenced from template.html (optional, but recommended to avoid inline styles)
+assets/*             # optional assets referenced from template.html
+```
+
+---
+
+## Run locally 🚀
+
+### With Docker (recommended)
+
+Builds a single image containing both the Java function and the Node sidecar (started by `start.sh`):
+
+```bash
+docker build -t pagopa-pdf-engine .
+docker run -p 7071:80 pagopa-pdf-engine
+```
+
+Sample call:
+
+```bash
 curl --location 'http://localhost:7071/generate-pdf' \
---header 'Ocp-Apim-Subscription-Key;' \
---form 'template=@"template.zip"' \
---form 'data="{
-		\"transaction\": {
-			\"id\": \"F57E2F8E-25FF-4183-AB7B-4A5EC1A96644\",
-			\"timestamp\": \"2020-07-10 15:00:00.000\",
-			\"amount\": 300.00,
-			\"psp\": {
-				\"name\": \"Nexi\",
-				\"fee\": {
-					\"amount\": 2.00
-				}
-			},
-			\"rrn\": \"1234567890\",
-			\"paymentMethod\": {
-				\"name\": \"Visa *1234\",
-				\"logo\": \"https://...\",
-				\"accountHolder\": \"Marzia Roccaraso\",
-				\"extraFee\": false
-			},
-			\"authCode\": \"9999999999\"
-		},
-		\"user\": {
-			\"data\": {
-				\"firstName\": \"Marzia\",
-				\"lastName\": \"Roccaraso\",
-				\"taxCode\": \"RCCMRZ88A52C409A\"
-			},
-			\"email\": \"email@test.it\"
-		},
-		\"cart\": {
-			\"items\": [{
-				\"refNumber\": {
-					\"type\": \"codiceAvviso\",
-					\"value\": \"123456789012345678\"
-				},
-				\"debtor\": {
-					\"fullName\": \"Giuseppe Bianchi\",
-					\"taxCode\": \"BNCGSP70A12F205X\"
-				},
-				\"payee\": {
-					\"name\": \"Comune di Controguerra\",
-					\"taxCode\": \"82001760675\"
-				},
-				\"subject\": \"TARI 2022\",
-				\"amount\": 150.00
-			}],
-			\"amountPartial\": 300.00
-		},
-		\"noticeCode\": \"noticeCodeTest\",
-		\"amount\": 100
-	}"' \
---form 'applySignature="false"' \
---form 'generateZipped="false"'
-``` 
-As you can see in the provided curl the first field `template` hold a zip file. The zip file contains the HTML template
-file and other optional attachments, such as CSS files, that will be used to generate the PDF document.
-
-> **Warning** \
-> The HTML template file must be named to match the value of the `HTML_TEMPLATE_FILE_NAME` environment variable 
-> (default is `template`) (example of HTML template file name: `template.html`)
-
-### Playwright version
-
-In order to use the newly introduced engine you may use the parameter
-
+  --header 'Ocp-Apim-Subscription-Key;' \
+  --form 'template=@"template.zip"' \
+  --form 'data="{
+        \"transaction\": {
+            \"id\": \"F57E2F8E-25FF-4183-AB7B-4A5EC1A96644\",
+            \"timestamp\": \"2020-07-10 15:00:00.000\",
+            \"amount\": 300.00,
+            \"psp\": { \"name\": \"Nexi\", \"fee\": { \"amount\": 2.00 } },
+            \"rrn\": \"1234567890\",
+            \"paymentMethod\": {
+                \"name\": \"Visa *1234\",
+                \"accountHolder\": \"Marzia Roccaraso\",
+                \"extraFee\": false
+            },
+            \"authCode\": \"9999999999\"
+        },
+        \"user\": {
+            \"data\": {
+                \"firstName\": \"Marzia\",
+                \"lastName\": \"Roccaraso\",
+                \"taxCode\": \"RCCMRZ88A52C409A\"
+            },
+            \"email\": \"email@test.it\"
+        },
+        \"cart\": {
+            \"items\": [{
+                \"refNumber\": { \"type\": \"codiceAvviso\", \"value\": \"123456789012345678\" },
+                \"debtor\": { \"fullName\": \"Giuseppe Bianchi\", \"taxCode\": \"BNCGSP70A12F205X\" },
+                \"payee\": { \"name\": \"Comune di Controguerra\", \"taxCode\": \"82001760675\" },
+                \"subject\": \"TARI 2022\",
+                \"amount\": 150.00
+            }],
+            \"amountPartial\": 300.00
+        },
+        \"noticeCode\": \"noticeCodeTest\",
+        \"amount\": 100
+    }"' \
+  --form 'applySignature="false"' \
+  --form 'generateZipped="false"' \
+  --output receipt.pdf
 ```
-...
---form 'generatorType="PLAYWRIGHT"'
-``` 
 
-The two values available are PLAYWRIGHT and ITEXT (the value defaults to ITEXT currently)
+### Java function with Maven
+
+Prerequisites: `git`, `maven`, JDK 17. The Node sidecar must be reachable on `PDF_ENGINE_NODE_GENERATE_ENDPOINT` (default `http://localhost:3000`).
+
+```bash
+mvn clean package
+mvn azure-functions:run
+```
+
+### Node sidecar standalone
+
+Prerequisites: Node.js ≥ 24, Yarn 1.x and a Chrome binary (either set `PUPPETEER_EXECUTABLE_PATH` to a local Chrome, or unset `PUPPETEER_SKIP_DOWNLOAD` so Puppeteer downloads its bundled one — note this won't be the pinned Chrome 127).
+
+```bash
+cd node
+yarn install
+# Optional: point to a local Chrome binary
+# export PUPPETEER_EXECUTABLE_PATH=/path/to/chrome
+yarn start          # listens on port 3000
+```
 
 ---
 
-## Develop Locally 💻
+## Testing 🧪
 
-### Prerequisites
-- git
-- maven
-- jdk-11
+### Unit tests
 
-### Testing 🧪
+Java:
 
-#### Unit testing
+```bash
+mvn clean verify
+```
 
-To run the **Junit** tests:
+Node:
 
-`mvn clean verify`
+```bash
+cd node
+yarn install
+yarn test            # or: yarn test:coverage
+```
 
-#### Integration testing
-From `./integration-test/src`
+### Integration tests
 
-1. `yarn install`
-2. `yarn test`
-#### Performance testing
+```bash
+cd integration-test/src
+yarn install
+yarn test
+```
 
+### Performance tests
 
+k6 scenarios live under [`performance-test/`](./performance-test/). The reference scenario is `constant-arrival-rate` at 50 req/s for 3 minutes (`performance-test/src/test-types/constant.json`).
+
+```bash
+cd performance-test
+./run_performance_test.sh
+```
+
+Per-phase timings emitted by the Node sidecar (`PERF_LOG=true`) are available in Application Insights as custom events named `PDF_ENGINE_NODE` with `properties.type = "PDF_ENGINE_NODE_PERF"`.
+
+---
 
 ## Contributors 👥
 Made with ❤️ by PagoPa S.p.A.
 
 ### Maintainers
-See `CODEOWNERS` file
+See `CODEOWNERS` file.

--- a/README.md
+++ b/README.md
@@ -177,7 +177,6 @@ ENV PUPPETEER_EXECUTABLE_PATH=/usr/src/app/.cache/puppeteer/chrome/linux-${PINNE
 | `PUPPETEER_EXECUTABLE_PATH` | set by the Dockerfile to the pinned Chrome | Override the Chrome binary used by Puppeteer |
 | `PUPPETEER_CACHE_DIR` | `/usr/src/app/.cache/puppeteer` | Where Puppeteer looks for installed browsers |
 | `PUPPETEER_SKIP_DOWNLOAD` | `true` in the image | Skip automatic Chrome download during `yarn install` |
-| `PDF_CONCURRENCY` | _unset_ (unlimited) | Optional per-process cap on concurrent `generatePdf` invocations. Set to e.g. `2 × vCPU` in production to protect Chromium; leave unset for k6 perf tests to avoid Little's-law artefacts. |
 | `CHECK_SIZE_INTERVAL` | `100` (ms) | Polling interval used by `waitForRender` |
 | `MIN_STABLE_SIZE_ITERATIONS` | `3` | Number of stable polls before the page is considered fully rendered |
 | `PERF_LOG` | `true` | Emit fine-grained per-phase timings as App Insights `PDF_ENGINE_NODE_PERF_*` custom events |

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ ENV PUPPETEER_EXECUTABLE_PATH=/usr/src/app/.cache/puppeteer/chrome/linux-${PINNE
 | `PUPPETEER_SKIP_DOWNLOAD` | `true` in the image | Skip automatic Chrome download during `yarn install` |
 | `CHECK_SIZE_INTERVAL` | `100` (ms) | Polling interval used by `waitForRender` |
 | `MIN_STABLE_SIZE_ITERATIONS` | `3` | Number of stable polls before the page is considered fully rendered |
-| `PERF_LOG` | `true` | Emit fine-grained per-phase timings as App Insights `PDF_ENGINE_NODE_PERF_*` custom events |
+| `PERF_LOG` | `false` | When set to `1`/`true`/`yes`, emit fine-grained per-phase timings as App Insights `PDF_ENGINE_NODE` custom events with `properties.type = "PDF_ENGINE_NODE_PERF"`. Disabled by default to avoid telemetry noise/cost in production. |
 | `APPLICATIONINSIGHTS_CONNECTION_STRING` | — | App Insights connection string for telemetry |
 
 ### Template zip layout

--- a/node/Dockerfile
+++ b/node/Dockerfile
@@ -10,6 +10,22 @@ WORKDIR /usr/src/build
 # the browser lives in ~/.cache/puppeteer, NOT in node_modules/puppeteer).
 ENV PUPPETEER_CACHE_DIR=/usr/src/build/.cache/puppeteer
 
+# --- Performance pinning ---------------------------------------------------
+# Puppeteer 25.x bundles Chrome 138+, which exhibits a measurable PDF
+# generation slowdown under load compared to Chrome 127 (last version
+# bundled with puppeteer 22.x, used by app v2.10.23 baseline).
+# We therefore:
+#   1) skip the automatic Chrome download during `yarn install`;
+#   2) install the older Chrome 127.0.6533.88 explicitly via @puppeteer/browsers
+#      into the same PUPPETEER_CACHE_DIR;
+#   3) tell Puppeteer to use that binary at runtime (PUPPETEER_EXECUTABLE_PATH
+#      is set on the runtime stage below).
+# Change PINNED_CHROME_VERSION to override.
+ENV PUPPETEER_SKIP_DOWNLOAD=true
+ARG PINNED_CHROME_VERSION=127.0.6533.88
+ENV PINNED_CHROME_VERSION=${PINNED_CHROME_VERSION}
+# ---------------------------------------------------------------------------
+
 # Enable Yarn with package.json version
 RUN corepack enable
 
@@ -18,6 +34,12 @@ COPY package.json yarn.lock ./
 
 # Install only production dependencies (no devDependencies) and freeze lockfile to ensure reproducible builds
 RUN yarn install --frozen-lockfile --production
+
+# Install the pinned Chrome version into PUPPETEER_CACHE_DIR.
+# @puppeteer/browsers is already a transitive dependency of puppeteer.
+RUN npx --yes @puppeteer/browsers install chrome@${PINNED_CHROME_VERSION} \
+        --path ${PUPPETEER_CACHE_DIR} \
+    && ls -la ${PUPPETEER_CACHE_DIR}/chrome/
 
 # Copy source code to the build stage
 COPY . .
@@ -33,6 +55,11 @@ WORKDIR /usr/src/app
 
 # Tell Puppeteer where to find the Chromium copied from the builder stage.
 ENV PUPPETEER_CACHE_DIR=/usr/src/app/.cache/puppeteer
+
+# Pin runtime to the legacy Chrome installed in the builder stage.
+# The exact path depends on the version installed above.
+ARG PINNED_CHROME_VERSION=127.0.6533.88
+ENV PUPPETEER_EXECUTABLE_PATH=/usr/src/app/.cache/puppeteer/chrome/linux-${PINNED_CHROME_VERSION}/chrome-linux64/chrome
 
 COPY ./package.json /usr/src/app/package.json
 COPY --from=builder /usr/src/build/pdf-generate /usr/src/app/pdf-generate

--- a/node/package.json
+++ b/node/package.json
@@ -25,7 +25,7 @@
     "i18next": "^25.8.14",
     "multer": "^1.4.5-lts.1",
     "nodemon": "^3.0.1",
-    "puppeteer": "^24.42.0",
+    "puppeteer": "25.0.4",
     "qrcode-svg": "^1.1.0",
     "uuid": "^14.0.0"
   },

--- a/node/pdf-generate/handlers.js
+++ b/node/pdf-generate/handlers.js
@@ -1,13 +1,10 @@
-const puppeteer = require('puppeteer');
 const path = require('path');
 const fs = require('fs');
 const readFileSync = require('fs').readFileSync
 const rmSync = require('fs').rmSync
 const os = require('os');
-const {getBrowserSession, closeBrowserSession} = require('./utils/browserManager');
+const {getBrowserSession} = require('./utils/browserManager');
 const buildResponseBody = require('./utils/buildUtils');
-const multer = require('multer');
-const express = require('express');
 let handlebars = require("handlebars");
 const packageJson = require("../package.json");
 var AdmZip = require("adm-zip");
@@ -157,7 +154,6 @@ const generatePdf = async function (req, res, next) {
 
         let data = req.body.data;
         let title = req.body.title;
-        let renderMode = req.body.renderMode || 'handlebar';
 
         if (title == undefined) {
             title = "Documento PDF PagoPA";

--- a/node/pdf-generate/handlers.js
+++ b/node/pdf-generate/handlers.js
@@ -184,7 +184,7 @@ const generatePdf = async function (req, res, next) {
 
         try {
             await page.goto('file:' + path.join(workingDir, "compiledTemplate.html"), {
-                waitUntil: ['load', 'domcontentloaded']
+                waitUntil: ['domcontentloaded', 'networkidle0']
             });
             // path, can be relative or absolute path
             //await page.addStyleTag({path: path.join(workingDir, "style.css")});
@@ -252,18 +252,32 @@ const generatePdf = async function (req, res, next) {
 }
 
 const waitForRender = async (page, timeout = 30000) => {
-    const checkInterval = process.env.CHECK_SIZE_INTERVAL || 100;
+    const checkInterval = Number(process.env.CHECK_SIZE_INTERVAL) || 100;
     const maxChecks = timeout / checkInterval;
     let lastSize = 0;
     let checkCounts = 1;
     let countStableSizeIterations = 0;
-    const minStableSizeIterations = process.env.MIN_STABLE_SIZE_ITERATIONS || 3;
+    const minStableSizeIterations = Number(process.env.MIN_STABLE_SIZE_ITERATIONS) || 3;
+
+    // Wait for fonts to be ready up-front
+    try {
+        await page.evaluate(() => document.fonts?.ready);
+    } catch (_) { /* ignore: page may have already been torn down */ }
 
     while (checkCounts++ <= maxChecks) {
-        let html = await page.content();
-        let currentSize = html.length;
+        // Previously we used `await page.content()` which serializes the
+        // *entire* DOM and ships it back over CDP on every iteration.
+        // Reading just two integers from the page is orders of magnitude
+        // cheaper and still detects when rendering has stabilised.
+        const currentSize = await page.evaluate(() => {
+            const body = document.body;
+            if (!body) return 0;
+            // Combine length + scrollHeight so we catch both DOM mutations
+            // and reflow-induced size changes (e.g. async font loading).
+            return body.innerHTML.length * 31 + body.scrollHeight;
+        });
 
-        if (lastSize != 0 && currentSize == lastSize)
+        if (lastSize !== 0 && currentSize === lastSize)
             countStableSizeIterations++;
         else
             countStableSizeIterations = 0;
@@ -273,7 +287,7 @@ const waitForRender = async (page, timeout = 30000) => {
         }
 
         lastSize = currentSize;
-        await new Promise(r => setTimeout(r, checkInterval))
+        await new Promise(r => setTimeout(r, checkInterval));
     }
 };
 

--- a/node/pdf-generate/handlers.js
+++ b/node/pdf-generate/handlers.js
@@ -303,7 +303,7 @@ const generatePdf = async function (req, res, next) {
         try {
             const endGoto = perf.start('page_goto');
             await page.goto('file:' + path.join(workingDir, "compiledTemplate.html"), {
-                waitUntil: ['domcontentloaded', 'networkidle0']
+                waitUntil: ['load', 'domcontentloaded']
             });
             endGoto();
             // path, can be relative or absolute path

--- a/node/pdf-generate/handlers.js
+++ b/node/pdf-generate/handlers.js
@@ -30,9 +30,37 @@ const PERF_LOG = /^(1|true|yes)$/i.test(String(process.env.PERF_LOG || true));
 function nowNs() { return process.hrtime.bigint(); }
 function nsToMs(ns) { return Number(ns) / 1e6; }
 
+// Emit a perf event through Application Insights (trackCustomEvent) and,
+// as a fallback for local runs without telemetry, also to stdout.
+// Kept centralized so the payload shape stays consistent across all phases.
+function emitPerfEvent(name, properties, measurements) {
+    trackCustomEvent({
+        name: "PDF_ENGINE_NODE",
+        properties: {
+            type: "PDF_ENGINE_NODE_PERF",
+            title: name,
+            ...properties
+        },
+        measurements
+    });
+    // Mirror to console for local development / docker logs.
+    if (!telemetryClient) {
+        console.log(`PERF | ${name} ${JSON.stringify({ ...properties, ...measurements })}`);
+    }
+}
+
 function createPerfTracker(reqId) {
     const phases = {};
     const startTotal = nowNs();
+    const recordPhase = (phaseName, ms) => {
+        phases[phaseName] = (phases[phaseName] || 0) + ms;
+        emitPerfEvent("PDF_ENGINE_NODE_PERF_PHASE", {
+            reqId,
+            phase: phaseName
+        }, {
+            duration_ms: ms
+        });
+    };
     return {
         reqId,
         // Measure a synchronous or async function call.
@@ -42,29 +70,34 @@ function createPerfTracker(reqId) {
             try {
                 return await fn();
             } finally {
-                const ms = nsToMs(nowNs() - s);
-                phases[name] = (phases[name] || 0) + ms;
-                console.log(`PERF | reqId=${reqId} phase=${name} ms=${ms.toFixed(2)}`);
+                recordPhase(name, nsToMs(nowNs() - s));
             }
         },
         // Manual span (when measure() doesn't fit, e.g. interleaved code).
         start(name) {
             if (!PERF_LOG) return () => {};
             const s = nowNs();
-            return () => {
-                const ms = nsToMs(nowNs() - s);
-                phases[name] = (phases[name] || 0) + ms;
-                console.log(`PERF | reqId=${reqId} phase=${name} ms=${ms.toFixed(2)}`);
-            };
+            return () => recordPhase(name, nsToMs(nowNs() - s));
         },
         flush(extra) {
             if (!PERF_LOG) return;
             const total = nsToMs(nowNs() - startTotal);
-            console.log(
-                `PERF_TOTAL | reqId=${reqId} total_ms=${total.toFixed(2)} ` +
-                `phases=${JSON.stringify(phases)}` +
-                (extra ? ` extra=${JSON.stringify(extra)}` : '')
-            );
+            // Build a measurements object: total_ms + every phase as its own
+            // numeric metric (App Insights will index them as customMetrics).
+            const measurements = { total_ms: total };
+            for (const [k, v] of Object.entries(phases)) {
+                measurements[`phase_${k}_ms`] = v;
+            }
+            if (extra) {
+                for (const [k, v] of Object.entries(extra)) {
+                    if (typeof v === 'number') measurements[k] = v;
+                }
+            }
+            emitPerfEvent("PDF_ENGINE_NODE_PERF_TOTAL", {
+                reqId,
+                phases: JSON.stringify(phases),
+                extra: extra ? JSON.stringify(extra) : undefined
+            }, measurements);
         }
     };
 }
@@ -369,7 +402,11 @@ const waitForRender = async (page, timeout = 30000) => {
         await page.evaluate(() => document.fonts?.ready);
     } catch (_) { /* ignore: page may have already been torn down */ }
     if (PERF_LOG) {
-        console.log(`PERF | phase=fonts_ready ms=${nsToMs(nowNs() - fontsStart).toFixed(2)}`);
+        emitPerfEvent("PDF_ENGINE_NODE_PERF_PHASE", {
+            phase: "fonts_ready"
+        }, {
+            duration_ms: nsToMs(nowNs() - fontsStart)
+        });
     }
 
     let iterations = 0;
@@ -383,7 +420,12 @@ const waitForRender = async (page, timeout = 30000) => {
         });
         if (PERF_LOG && iterations <= 3) {
             // log only the first few to avoid noise
-            console.log(`PERF | phase=wait_iter#${iterations} ms=${nsToMs(nowNs() - iterStart).toFixed(2)} size=${currentSize}`);
+            emitPerfEvent("PDF_ENGINE_NODE_PERF_PHASE", {
+                phase: `wait_iter_${iterations}`
+            }, {
+                duration_ms: nsToMs(nowNs() - iterStart),
+                size: currentSize
+            });
         }
 
         if (lastSize !== 0 && currentSize === lastSize)

--- a/node/pdf-generate/handlers.js
+++ b/node/pdf-generate/handlers.js
@@ -12,96 +12,16 @@ let handlebars = require("handlebars");
 const packageJson = require("../package.json");
 var AdmZip = require("adm-zip");
 const fse = require('fs-extra');
-const telemetryClient = require('./utils/telemetry');
+const {
+    trackCustomEvent,
+    createPerfTracker,
+    emitPerfPhase,
+    PERF_LOG,
+    nowNs,
+    nsToMs
+} = require('./utils/telemetry');
 const crypto = require('crypto');
 
-// ---------------------------------------------------------------------------
-// Lightweight performance instrumentation.
-//
-// Activate with PERF_LOG=1 (or =true). When disabled the helper functions
-// reduce to no-ops, so leaving the calls in production is safe.
-// All timings are in milliseconds with sub-ms precision (process.hrtime.bigint).
-// Output format (single line, easy to grep / parse):
-//   PERF | reqId=<id> phase=<name> ms=<value>
-//   PERF_TOTAL | reqId=<id> total_ms=<value> phases=<json>
-// ---------------------------------------------------------------------------
-const PERF_LOG = /^(1|true|yes)$/i.test(String(process.env.PERF_LOG || true));
-
-function nowNs() { return process.hrtime.bigint(); }
-function nsToMs(ns) { return Number(ns) / 1e6; }
-
-
-// Emit a perf event through Application Insights (trackCustomEvent) and,
-// as a fallback for local runs without telemetry, also to stdout.
-// Kept centralized so the payload shape stays consistent across all phases.
-function emitPerfEvent(name, properties, measurements) {
-    trackCustomEvent({
-        name: "PDF_ENGINE_NODE",
-        properties: {
-            type: "PDF_ENGINE_NODE_PERF",
-            title: name,
-            ...properties
-        },
-        measurements
-    });
-    // Mirror to console for local development / docker logs.
-    if (!telemetryClient) {
-        console.log(`PERF | ${name} ${JSON.stringify({ ...properties, ...measurements })}`);
-    }
-}
-
-function createPerfTracker(reqId) {
-    const phases = {};
-    const startTotal = nowNs();
-    const recordPhase = (phaseName, ms) => {
-        phases[phaseName] = (phases[phaseName] || 0) + ms;
-        emitPerfEvent("PDF_ENGINE_NODE_PERF_PHASE", {
-            reqId,
-            phase: phaseName
-        }, {
-            duration_ms: ms
-        });
-    };
-    return {
-        reqId,
-        // Measure a synchronous or async function call.
-        async measure(name, fn) {
-            if (!PERF_LOG) return fn();
-            const s = nowNs();
-            try {
-                return await fn();
-            } finally {
-                recordPhase(name, nsToMs(nowNs() - s));
-            }
-        },
-        // Manual span (when measure() doesn't fit, e.g. interleaved code).
-        start(name) {
-            if (!PERF_LOG) return () => {};
-            const s = nowNs();
-            return () => recordPhase(name, nsToMs(nowNs() - s));
-        },
-        flush(extra) {
-            if (!PERF_LOG) return;
-            const total = nsToMs(nowNs() - startTotal);
-            // Build a measurements object: total_ms + every phase as its own
-            // numeric metric (App Insights will index them as customMetrics).
-            const measurements = { total_ms: total };
-            for (const [k, v] of Object.entries(phases)) {
-                measurements[`phase_${k}_ms`] = v;
-            }
-            if (extra) {
-                for (const [k, v] of Object.entries(extra)) {
-                    if (typeof v === 'number') measurements[k] = v;
-                }
-            }
-            emitPerfEvent("PDF_ENGINE_NODE_PERF_TOTAL", {
-                reqId,
-                phases: JSON.stringify(phases),
-                extra: extra ? JSON.stringify(extra) : undefined
-            }, measurements);
-        }
-    };
-}
 
 // Cache of compiled Handlebars templates keyed by the SHA-1 of the
 // template source. The same `template.html` is used over and over again
@@ -145,14 +65,6 @@ const shutdown = async function (req, res, server) {
     process.exit(0);
 }
 
-function trackCustomEvent(msg) {
-    if (!telemetryClient) return;
-    try {
-        telemetryClient.trackEvent(msg);
-    } catch (e) {
-        console.error("custom event tracking failed", e);
-    }
-}
 
 const generatePdf = async function (req, res, next) {
 
@@ -403,11 +315,7 @@ const waitForRender = async (page, timeout = 30000) => {
         await page.evaluate(() => document.fonts?.ready);
     } catch (_) { /* ignore: page may have already been torn down */ }
     if (PERF_LOG) {
-        emitPerfEvent("PDF_ENGINE_NODE_PERF_PHASE", {
-            phase: "fonts_ready"
-        }, {
-            duration_ms: nsToMs(nowNs() - fontsStart)
-        });
+        emitPerfPhase("fonts_ready", nsToMs(nowNs() - fontsStart));
     }
 
     let iterations = 0;
@@ -421,12 +329,12 @@ const waitForRender = async (page, timeout = 30000) => {
         });
         if (PERF_LOG && iterations <= 3) {
             // log only the first few to avoid noise
-            emitPerfEvent("PDF_ENGINE_NODE_PERF_PHASE", {
-                phase: `wait_iter_${iterations}`
-            }, {
-                duration_ms: nsToMs(nowNs() - iterStart),
-                size: currentSize
-            });
+            emitPerfPhase(
+                `wait_iter_${iterations}`,
+                nsToMs(nowNs() - iterStart),
+                {},
+                { size: currentSize }
+            );
         }
 
         if (lastSize !== 0 && currentSize === lastSize)

--- a/node/pdf-generate/handlers.js
+++ b/node/pdf-generate/handlers.js
@@ -30,6 +30,43 @@ const PERF_LOG = /^(1|true|yes)$/i.test(String(process.env.PERF_LOG || true));
 function nowNs() { return process.hrtime.bigint(); }
 function nsToMs(ns) { return Number(ns) / 1e6; }
 
+// ---------------------------------------------------------------------------
+// Per-process concurrency limiter for generatePdf.
+//
+// The previous implementation let an unbounded number of concurrent requests
+// hit the single shared Chromium browser. Performance data showed that under
+// load every page.* operation degraded ~100x (newPage from ~50ms -> ~5s)
+// because Chromium became oversubscribed.
+//
+// We serialize generations to at most PDF_CONCURRENCY requests at a time
+// (default = number of vCPUs). Excess requests wait in a FIFO queue
+// instead of piling up on Chromium. Override with the PDF_CONCURRENCY env
+// var (set to a high number to effectively disable).
+// ---------------------------------------------------------------------------
+const PDF_CONCURRENCY = Math.max(
+    1,
+    Number(process.env.PDF_CONCURRENCY) || os.cpus().length
+);
+let _activeGenerations = 0;
+const _generationQueue = [];
+function acquireGenerationSlot() {
+    if (_activeGenerations < PDF_CONCURRENCY) {
+        _activeGenerations++;
+        return Promise.resolve();
+    }
+    return new Promise(resolve => _generationQueue.push(resolve));
+}
+function releaseGenerationSlot() {
+    if (_generationQueue.length > 0) {
+        // Hand the slot directly to the next waiter (no counter change).
+        const next = _generationQueue.shift();
+        next();
+    } else {
+        _activeGenerations = Math.max(0, _activeGenerations - 1);
+    }
+}
+console.info(`PDF generation concurrency limit = ${PDF_CONCURRENCY}`);
+
 // Emit a perf event through Application Insights (trackCustomEvent) and,
 // as a fallback for local runs without telemetry, also to stdout.
 // Kept centralized so the payload shape stays consistent across all phases.
@@ -155,6 +192,15 @@ function trackCustomEvent(msg) {
 
 const generatePdf = async function (req, res, next) {
 
+    // Acquire a concurrency slot BEFORE doing any heavy work so we don't
+    // pile up requests on Chromium. We also measure the time spent waiting
+    // in the queue: it's a key signal for capacity planning.
+    const reqId = (req.headers && (req.headers['x-request-id'] || req.headers['x-correlation-id']))
+        || crypto.randomBytes(6).toString('hex');
+    const perf = createPerfTracker(reqId);
+    const endQueueWait = perf.start('concurrency_wait');
+    await acquireGenerationSlot();
+    endQueueWait();
 
     trackCustomEvent({
         name: "PDF_ENGINE_NODE",
@@ -168,9 +214,6 @@ const generatePdf = async function (req, res, next) {
     var page;
 
     let timestampLog = `${Date.now()}`;
-    const reqId = (req.headers && (req.headers['x-request-id'] || req.headers['x-correlation-id']))
-        || crypto.randomBytes(6).toString('hex');
-    const perf = createPerfTracker(reqId);
     let zipEntryCount = 0;
     let waitRenderIterations = 0;
     let pdfBytes = 0;
@@ -384,6 +427,9 @@ const generatePdf = async function (req, res, next) {
             waitRenderIterations,
             pdfBytes
         });
+        // Release the slot LAST so the next queued request only starts after
+        // we have fully cleaned up (page.close, rmdir).
+        releaseGenerationSlot();
     }
 
 }

--- a/node/pdf-generate/handlers.js
+++ b/node/pdf-generate/handlers.js
@@ -33,23 +33,35 @@ function nsToMs(ns) { return Number(ns) / 1e6; }
 // ---------------------------------------------------------------------------
 // Per-process concurrency limiter for generatePdf.
 //
-// The previous implementation let an unbounded number of concurrent requests
-// hit the single shared Chromium browser. Performance data showed that under
-// load every page.* operation degraded ~100x (newPage from ~50ms -> ~5s)
-// because Chromium became oversubscribed.
+// Without a limit, an unbounded number of concurrent requests can hit the
+// single shared Chromium browser. Performance data showed that under load
+// every page.* operation degraded ~100x (newPage from ~50ms -> ~5s) because
+// Chromium became oversubscribed.
 //
-// We serialize generations to at most PDF_CONCURRENCY requests at a time
-// (default = number of vCPUs). Excess requests wait in a FIFO queue
-// instead of piling up on Chromium. Override with the PDF_CONCURRENCY env
-// var (set to a high number to effectively disable).
+// This limiter is OPT-IN: the limit is applied ONLY if the PDF_CONCURRENCY
+// environment variable is set to a positive integer. When unset (or invalid),
+// no limit is enforced and the queue/wait code is bypassed entirely - this
+// keeps the historical behavior in environments (e.g. perf tests with k6 +
+// fixed maxVUs) where queueing artificially lowers measured throughput due
+// to Little's law.
+//
+// Recommended values:
+//   - production:    PDF_CONCURRENCY = vCPU  (e.g. 4 on a P2v3) or 2*vCPU
+//                    to absorb micro-bursts while protecting Chromium
+//   - perf test k6:  do not set (unlimited) so total throughput isn't
+//                    bounded by maxVUs / queue_latency
+//   - local dev:     do not set
 // ---------------------------------------------------------------------------
-const PDF_CONCURRENCY = Math.max(
-    1,
-    Number(process.env.PDF_CONCURRENCY) || os.cpus().length
-);
+const _rawConcurrency = Number(process.env.PDF_CONCURRENCY);
+const PDF_CONCURRENCY = Number.isFinite(_rawConcurrency) && _rawConcurrency > 0
+    ? Math.floor(_rawConcurrency)
+    : 0; // 0 => disabled (unlimited)
+const CONCURRENCY_ENABLED = PDF_CONCURRENCY > 0;
+
 let _activeGenerations = 0;
 const _generationQueue = [];
 function acquireGenerationSlot() {
+    if (!CONCURRENCY_ENABLED) return Promise.resolve();
     if (_activeGenerations < PDF_CONCURRENCY) {
         _activeGenerations++;
         return Promise.resolve();
@@ -57,6 +69,7 @@ function acquireGenerationSlot() {
     return new Promise(resolve => _generationQueue.push(resolve));
 }
 function releaseGenerationSlot() {
+    if (!CONCURRENCY_ENABLED) return;
     if (_generationQueue.length > 0) {
         // Hand the slot directly to the next waiter (no counter change).
         const next = _generationQueue.shift();
@@ -65,7 +78,11 @@ function releaseGenerationSlot() {
         _activeGenerations = Math.max(0, _activeGenerations - 1);
     }
 }
-console.info(`PDF generation concurrency limit = ${PDF_CONCURRENCY}`);
+console.info(
+    CONCURRENCY_ENABLED
+        ? `PDF generation concurrency limit = ${PDF_CONCURRENCY}`
+        : `PDF generation concurrency limit = DISABLED (set PDF_CONCURRENCY to enable)`
+);
 
 // Emit a perf event through Application Insights (trackCustomEvent) and,
 // as a fallback for local runs without telemetry, also to stdout.
@@ -195,12 +212,16 @@ const generatePdf = async function (req, res, next) {
     // Acquire a concurrency slot BEFORE doing any heavy work so we don't
     // pile up requests on Chromium. We also measure the time spent waiting
     // in the queue: it's a key signal for capacity planning.
+    // When PDF_CONCURRENCY is not set, acquire/release are no-ops and we
+    // skip the concurrency_wait phase entirely to avoid noise in metrics.
     const reqId = (req.headers && (req.headers['x-request-id'] || req.headers['x-correlation-id']))
         || crypto.randomBytes(6).toString('hex');
     const perf = createPerfTracker(reqId);
-    const endQueueWait = perf.start('concurrency_wait');
-    await acquireGenerationSlot();
-    endQueueWait();
+    if (CONCURRENCY_ENABLED) {
+        const endQueueWait = perf.start('concurrency_wait');
+        await acquireGenerationSlot();
+        endQueueWait();
+    }
 
     trackCustomEvent({
         name: "PDF_ENGINE_NODE",

--- a/node/pdf-generate/handlers.js
+++ b/node/pdf-generate/handlers.js
@@ -30,59 +30,6 @@ const PERF_LOG = /^(1|true|yes)$/i.test(String(process.env.PERF_LOG || true));
 function nowNs() { return process.hrtime.bigint(); }
 function nsToMs(ns) { return Number(ns) / 1e6; }
 
-// ---------------------------------------------------------------------------
-// Per-process concurrency limiter for generatePdf.
-//
-// Without a limit, an unbounded number of concurrent requests can hit the
-// single shared Chromium browser. Performance data showed that under load
-// every page.* operation degraded ~100x (newPage from ~50ms -> ~5s) because
-// Chromium became oversubscribed.
-//
-// This limiter is OPT-IN: the limit is applied ONLY if the PDF_CONCURRENCY
-// environment variable is set to a positive integer. When unset (or invalid),
-// no limit is enforced and the queue/wait code is bypassed entirely - this
-// keeps the historical behavior in environments (e.g. perf tests with k6 +
-// fixed maxVUs) where queueing artificially lowers measured throughput due
-// to Little's law.
-//
-// Recommended values:
-//   - production:    PDF_CONCURRENCY = vCPU  (e.g. 4 on a P2v3) or 2*vCPU
-//                    to absorb micro-bursts while protecting Chromium
-//   - perf test k6:  do not set (unlimited) so total throughput isn't
-//                    bounded by maxVUs / queue_latency
-//   - local dev:     do not set
-// ---------------------------------------------------------------------------
-const _rawConcurrency = Number(process.env.PDF_CONCURRENCY);
-const PDF_CONCURRENCY = Number.isFinite(_rawConcurrency) && _rawConcurrency > 0
-    ? Math.floor(_rawConcurrency)
-    : 0; // 0 => disabled (unlimited)
-const CONCURRENCY_ENABLED = PDF_CONCURRENCY > 0;
-
-let _activeGenerations = 0;
-const _generationQueue = [];
-function acquireGenerationSlot() {
-    if (!CONCURRENCY_ENABLED) return Promise.resolve();
-    if (_activeGenerations < PDF_CONCURRENCY) {
-        _activeGenerations++;
-        return Promise.resolve();
-    }
-    return new Promise(resolve => _generationQueue.push(resolve));
-}
-function releaseGenerationSlot() {
-    if (!CONCURRENCY_ENABLED) return;
-    if (_generationQueue.length > 0) {
-        // Hand the slot directly to the next waiter (no counter change).
-        const next = _generationQueue.shift();
-        next();
-    } else {
-        _activeGenerations = Math.max(0, _activeGenerations - 1);
-    }
-}
-console.info(
-    CONCURRENCY_ENABLED
-        ? `PDF generation concurrency limit = ${PDF_CONCURRENCY}`
-        : `PDF generation concurrency limit = DISABLED (set PDF_CONCURRENCY to enable)`
-);
 
 // Emit a perf event through Application Insights (trackCustomEvent) and,
 // as a fallback for local runs without telemetry, also to stdout.
@@ -209,19 +156,9 @@ function trackCustomEvent(msg) {
 
 const generatePdf = async function (req, res, next) {
 
-    // Acquire a concurrency slot BEFORE doing any heavy work so we don't
-    // pile up requests on Chromium. We also measure the time spent waiting
-    // in the queue: it's a key signal for capacity planning.
-    // When PDF_CONCURRENCY is not set, acquire/release are no-ops and we
-    // skip the concurrency_wait phase entirely to avoid noise in metrics.
     const reqId = (req.headers && (req.headers['x-request-id'] || req.headers['x-correlation-id']))
         || crypto.randomBytes(6).toString('hex');
     const perf = createPerfTracker(reqId);
-    if (CONCURRENCY_ENABLED) {
-        const endQueueWait = perf.start('concurrency_wait');
-        await acquireGenerationSlot();
-        endQueueWait();
-    }
 
     trackCustomEvent({
         name: "PDF_ENGINE_NODE",
@@ -448,9 +385,6 @@ const generatePdf = async function (req, res, next) {
             waitRenderIterations,
             pdfBytes
         });
-        // Release the slot LAST so the next queued request only starts after
-        // we have fully cleaned up (page.close, rmdir).
-        releaseGenerationSlot();
     }
 
 }

--- a/node/pdf-generate/handlers.js
+++ b/node/pdf-generate/handlers.js
@@ -15,6 +15,60 @@ const fse = require('fs-extra');
 const telemetryClient = require('./utils/telemetry');
 const crypto = require('crypto');
 
+// ---------------------------------------------------------------------------
+// Lightweight performance instrumentation.
+//
+// Activate with PERF_LOG=1 (or =true). When disabled the helper functions
+// reduce to no-ops, so leaving the calls in production is safe.
+// All timings are in milliseconds with sub-ms precision (process.hrtime.bigint).
+// Output format (single line, easy to grep / parse):
+//   PERF | reqId=<id> phase=<name> ms=<value>
+//   PERF_TOTAL | reqId=<id> total_ms=<value> phases=<json>
+// ---------------------------------------------------------------------------
+const PERF_LOG = /^(1|true|yes)$/i.test(String(process.env.PERF_LOG || true));
+
+function nowNs() { return process.hrtime.bigint(); }
+function nsToMs(ns) { return Number(ns) / 1e6; }
+
+function createPerfTracker(reqId) {
+    const phases = {};
+    const startTotal = nowNs();
+    return {
+        reqId,
+        // Measure a synchronous or async function call.
+        async measure(name, fn) {
+            if (!PERF_LOG) return fn();
+            const s = nowNs();
+            try {
+                return await fn();
+            } finally {
+                const ms = nsToMs(nowNs() - s);
+                phases[name] = (phases[name] || 0) + ms;
+                console.log(`PERF | reqId=${reqId} phase=${name} ms=${ms.toFixed(2)}`);
+            }
+        },
+        // Manual span (when measure() doesn't fit, e.g. interleaved code).
+        start(name) {
+            if (!PERF_LOG) return () => {};
+            const s = nowNs();
+            return () => {
+                const ms = nsToMs(nowNs() - s);
+                phases[name] = (phases[name] || 0) + ms;
+                console.log(`PERF | reqId=${reqId} phase=${name} ms=${ms.toFixed(2)}`);
+            };
+        },
+        flush(extra) {
+            if (!PERF_LOG) return;
+            const total = nsToMs(nowNs() - startTotal);
+            console.log(
+                `PERF_TOTAL | reqId=${reqId} total_ms=${total.toFixed(2)} ` +
+                `phases=${JSON.stringify(phases)}` +
+                (extra ? ` extra=${JSON.stringify(extra)}` : '')
+            );
+        }
+    };
+}
+
 // Cache of compiled Handlebars templates keyed by the SHA-1 of the
 // template source. The same `template.html` is used over and over again
 // across requests, so recompiling it every time is pure overhead.
@@ -81,14 +135,22 @@ const generatePdf = async function (req, res, next) {
     var page;
 
     let timestampLog = `${Date.now()}`;
+    const reqId = (req.headers && (req.headers['x-request-id'] || req.headers['x-correlation-id']))
+        || crypto.randomBytes(6).toString('hex');
+    const perf = createPerfTracker(reqId);
+    let zipEntryCount = 0;
+    let waitRenderIterations = 0;
+    let pdfBytes = 0;
 
     console.time(timestampLog);
-    console.info(`Starting generate pdf nodejs function`);
+    console.info(`Starting generate pdf nodejs function reqId=${reqId}`);
 
     try {
 
         try {
+            const endMkdir = perf.start('mkdtemp');
             workingDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pdfenginetmp-'));
+            endMkdir();
         } catch (err) {
             trackCustomEvent({
                 name: "PDF_ENGINE_NODE",
@@ -109,28 +171,43 @@ const generatePdf = async function (req, res, next) {
         var zip = new AdmZip(req.file.buffer);
         var zipEntries = zip.getEntries();
 
-
+        // NOTE: previously fse.outputFile was fired in a fire-and-forget
+        // fashion inside the loop, which (a) made it impossible to know
+        // when the files were really on disk and (b) hid the real cost of
+        // this phase from any timing logs. We now await every write so the
+        // perf measurement is meaningful and the page.goto below cannot
+        // race the writes.
+        const endZip = perf.start('zip_extract');
+        const writes = [];
         for (const zipEntry of zipEntries) {
             if (!zipEntry.entryName.includes("._") && !zipEntry.isDirectory) {
-                fse.outputFile(path.join(workingDir, zipEntry.entryName), zipEntry.getData(), err => {
-                    if (err) {
-                        trackCustomEvent({
-                            name: "PDF_ENGINE_NODE",
-                            properties: {
-                                "type": "PDF_ENGINE_NODE_ERROR",
-                                "title": "outputFile error",
-                                "details": "An error occurred writing file " + zipEntry.entryName,
-                                "cause": err.toString()
-                            }
-                        });
-                        console.error(err);
-                    }
-                });
+                zipEntryCount++;
+                writes.push(
+                    fse.outputFile(path.join(workingDir, zipEntry.entryName), zipEntry.getData())
+                        .catch(err => {
+                            trackCustomEvent({
+                                name: "PDF_ENGINE_NODE",
+                                properties: {
+                                    "type": "PDF_ENGINE_NODE_ERROR",
+                                    "title": "outputFile error",
+                                    "details": "An error occurred writing file " + zipEntry.entryName,
+                                    "cause": err.toString()
+                                }
+                            });
+                            console.error(err);
+                        })
+                );
             }
         }
+        await Promise.all(writes);
+        endZip();
 
+        const endBrowser = perf.start('browser_session');
         const browser = await getBrowserSession();
+        endBrowser();
+        const endNewPage = perf.start('new_page');
         page = await browser.newPage();
+        endNewPage();
 
         let data = req.body.data;
         let title = req.body.title;
@@ -159,11 +236,19 @@ const generatePdf = async function (req, res, next) {
         try {
 
             const jsonData = JSON.parse(data);
+            const endRead = perf.start('read_template');
             let templateFile = readFileSync(path.join(workingDir, "template.html")).toString();
+            endRead();
+            const endCompile = perf.start('handlebars_compile');
             let template = getCompiledTemplate(templateFile);
+            endCompile();
             jsonData.tempPath = workingDir;
+            const endRender = perf.start('handlebars_render');
             let html = template(jsonData);
+            endRender();
+            const endWrite = perf.start('write_compiled_html');
             fs.writeFileSync(path.join(workingDir, "compiledTemplate.html"), html);
+            endWrite();
 
         } catch (err) {
             trackCustomEvent({
@@ -183,12 +268,17 @@ const generatePdf = async function (req, res, next) {
         }
 
         try {
+            const endGoto = perf.start('page_goto');
             await page.goto('file:' + path.join(workingDir, "compiledTemplate.html"), {
                 waitUntil: ['domcontentloaded', 'networkidle0']
             });
+            endGoto();
             // path, can be relative or absolute path
             //await page.addStyleTag({path: path.join(workingDir, "style.css")});
-            await waitForRender(page);
+            const endWait = perf.start('wait_for_render');
+            waitRenderIterations = await waitForRender(page);
+            endWait();
+            const endPdf = perf.start('page_pdf');
             await page.pdf({
                 path: path.join(workingDir, "pagopa-receipt.pdf"),
                 title: title,
@@ -196,6 +286,7 @@ const generatePdf = async function (req, res, next) {
                 landscape: false,
                 printBackground: true,
             });
+            endPdf();
         } catch (err) {
             trackCustomEvent({
                 name: "PDF_ENGINE_NODE",
@@ -222,8 +313,11 @@ const generatePdf = async function (req, res, next) {
             }
         });
         let content = readFileSync(path.join(workingDir, "pagopa-receipt.pdf"));
+        pdfBytes = content.length;
         res.setHeader('content-type', 'application/pdf');
+        const endSend = perf.start('res_send');
         res.send(content);
+        endSend();
 
     } catch (err) {
         trackCustomEvent({
@@ -240,13 +334,23 @@ const generatePdf = async function (req, res, next) {
         res.json(buildResponseBody(500, 'PDFE_902', "Error generating the PDF document"));
     } finally {
         if (page) {
+            const endClose = perf.start('page_close');
             await page.close();
+            endClose();
         }
 
         if (workingDir) {
+            const endRm = perf.start('rm_workdir');
             rmSync(workingDir, {recursive: true, force: true});
+            endRm();
         }
 
+        console.timeEnd(timestampLog);
+        perf.flush({
+            zipEntries: zipEntryCount,
+            waitRenderIterations,
+            pdfBytes
+        });
     }
 
 }
@@ -260,22 +364,27 @@ const waitForRender = async (page, timeout = 30000) => {
     const minStableSizeIterations = Number(process.env.MIN_STABLE_SIZE_ITERATIONS) || 3;
 
     // Wait for fonts to be ready up-front
+    const fontsStart = PERF_LOG ? nowNs() : null;
     try {
         await page.evaluate(() => document.fonts?.ready);
     } catch (_) { /* ignore: page may have already been torn down */ }
+    if (PERF_LOG) {
+        console.log(`PERF | phase=fonts_ready ms=${nsToMs(nowNs() - fontsStart).toFixed(2)}`);
+    }
 
+    let iterations = 0;
     while (checkCounts++ <= maxChecks) {
-        // Previously we used `await page.content()` which serializes the
-        // *entire* DOM and ships it back over CDP on every iteration.
-        // Reading just two integers from the page is orders of magnitude
-        // cheaper and still detects when rendering has stabilised.
+        iterations++;
+        const iterStart = PERF_LOG ? nowNs() : null;
         const currentSize = await page.evaluate(() => {
             const body = document.body;
             if (!body) return 0;
-            // Combine length + scrollHeight so we catch both DOM mutations
-            // and reflow-induced size changes (e.g. async font loading).
             return body.innerHTML.length * 31 + body.scrollHeight;
         });
+        if (PERF_LOG && iterations <= 3) {
+            // log only the first few to avoid noise
+            console.log(`PERF | phase=wait_iter#${iterations} ms=${nsToMs(nowNs() - iterStart).toFixed(2)} size=${currentSize}`);
+        }
 
         if (lastSize !== 0 && currentSize === lastSize)
             countStableSizeIterations++;
@@ -289,6 +398,7 @@ const waitForRender = async (page, timeout = 30000) => {
         lastSize = currentSize;
         await new Promise(r => setTimeout(r, checkInterval));
     }
+    return iterations;
 };
 
 module.exports = {info, generatePdf, shutdown};

--- a/node/pdf-generate/handlers.js
+++ b/node/pdf-generate/handlers.js
@@ -13,6 +13,32 @@ const packageJson = require("../package.json");
 var AdmZip = require("adm-zip");
 const fse = require('fs-extra');
 const telemetryClient = require('./utils/telemetry');
+const crypto = require('crypto');
+
+// Cache of compiled Handlebars templates keyed by the SHA-1 of the
+// template source. The same `template.html` is used over and over again
+// across requests, so recompiling it every time is pure overhead.
+// A small bounded LRU-like cache keeps memory usage in check.
+const TEMPLATE_CACHE_MAX = 32;
+const compiledTemplateCache = new Map();
+
+function getCompiledTemplate(source) {
+    const key = crypto.createHash('sha1').update(source).digest('hex');
+    let tpl = compiledTemplateCache.get(key);
+    if (tpl) {
+        // refresh LRU position
+        compiledTemplateCache.delete(key);
+        compiledTemplateCache.set(key, tpl);
+        return tpl;
+    }
+    tpl = handlebars.compile(source);
+    compiledTemplateCache.set(key, tpl);
+    if (compiledTemplateCache.size > TEMPLATE_CACHE_MAX) {
+        const oldest = compiledTemplateCache.keys().next().value;
+        compiledTemplateCache.delete(oldest);
+    }
+    return tpl;
+}
 
 
 const info = async function (req, res, next) {
@@ -134,7 +160,7 @@ const generatePdf = async function (req, res, next) {
 
             const jsonData = JSON.parse(data);
             let templateFile = readFileSync(path.join(workingDir, "template.html")).toString();
-            let template = handlebars.compile(templateFile);
+            let template = getCompiledTemplate(templateFile);
             jsonData.tempPath = workingDir;
             let html = template(jsonData);
             fs.writeFileSync(path.join(workingDir, "compiledTemplate.html"), html);

--- a/node/pdf-generate/utils/telemetry.js
+++ b/node/pdf-generate/utils/telemetry.js
@@ -10,4 +10,141 @@ if (connectionString) {
     }
 }
 
-module.exports = appInsights.defaultClient;
+const telemetryClient = appInsights.defaultClient;
+
+// ---------------------------------------------------------------------------
+// trackCustomEvent
+//
+// Thin wrapper around App Insights' trackEvent that no-ops when telemetry is
+// not configured (e.g. local development without a connection string) and
+// swallows any error so that telemetry issues never break the request flow.
+// ---------------------------------------------------------------------------
+function trackCustomEvent(msg) {
+    if (!telemetryClient) return;
+    try {
+        telemetryClient.trackEvent(msg);
+    } catch (e) {
+        console.error("custom event tracking failed", e);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Performance instrumentation.
+//
+// Disabled by default. Activate with PERF_LOG=1 (or =true / =yes).
+// When disabled the helpers degrade to no-ops.
+//
+// All timings are in milliseconds with sub-ms precision (process.hrtime.bigint).
+// Each phase is published twice on App Insights:
+//   - one PDF_ENGINE_NODE_PERF_PHASE event per phase (for percentiles per phase)
+//   - one PDF_ENGINE_NODE_PERF_TOTAL event per request, with the full breakdown
+//     in `measurements` (so KQL queries can correlate phases on the same row).
+// ---------------------------------------------------------------------------
+const PERF_LOG = /^(1|true|yes)$/i.test(String(process.env.PERF_LOG || ""));
+
+function nowNs() { return process.hrtime.bigint(); }
+function nsToMs(ns) { return Number(ns) / 1e6; }
+
+function emitPerfEvent(name, properties, measurements) {
+    trackCustomEvent({
+        name: "PDF_ENGINE_NODE",
+        properties: {
+            type: "PDF_ENGINE_NODE_PERF",
+            title: name,
+            ...properties
+        },
+        measurements
+    });
+    // Mirror to console for local development / docker logs when telemetry
+    // is not wired up.
+    if (!telemetryClient) {
+        console.log(`PERF | ${name} ${JSON.stringify({ ...properties, ...measurements })}`);
+    }
+}
+
+// Emit a single perf phase outside of a tracker (e.g. ad-hoc spans inside
+// helper functions). No-op when PERF_LOG is disabled.
+function emitPerfPhase(phase, durationMs, extraProps = {}, extraMeasurements = {}) {
+    if (!PERF_LOG) return;
+    emitPerfEvent("PDF_ENGINE_NODE_PERF_PHASE", {
+        phase,
+        ...extraProps
+    }, {
+        duration_ms: durationMs,
+        ...extraMeasurements
+    });
+}
+
+// Build a per-request tracker. Returns no-op stubs when PERF_LOG is disabled
+// so callers don't need to guard each call site.
+function createPerfTracker(reqId) {
+    if (!PERF_LOG) {
+        return {
+            reqId,
+            measure: async (_name, fn) => fn(),
+            start: () => () => {},
+            flush: () => {}
+        };
+    }
+
+    const phases = {};
+    const startTotal = nowNs();
+
+    const recordPhase = (phaseName, ms) => {
+        phases[phaseName] = (phases[phaseName] || 0) + ms;
+        emitPerfEvent("PDF_ENGINE_NODE_PERF_PHASE", {
+            reqId,
+            phase: phaseName
+        }, {
+            duration_ms: ms
+        });
+    };
+
+    return {
+        reqId,
+        // Measure a synchronous or async function call.
+        async measure(name, fn) {
+            const s = nowNs();
+            try {
+                return await fn();
+            } finally {
+                recordPhase(name, nsToMs(nowNs() - s));
+            }
+        },
+        // Manual span (when measure() doesn't fit, e.g. interleaved code).
+        start(name) {
+            const s = nowNs();
+            return () => recordPhase(name, nsToMs(nowNs() - s));
+        },
+        flush(extra) {
+            const total = nsToMs(nowNs() - startTotal);
+            // Build a measurements object: total_ms + every phase as its own
+            // numeric metric (App Insights will index them as customMetrics).
+            const measurements = { total_ms: total };
+            for (const [k, v] of Object.entries(phases)) {
+                measurements[`phase_${k}_ms`] = v;
+            }
+            if (extra) {
+                for (const [k, v] of Object.entries(extra)) {
+                    if (typeof v === 'number') measurements[k] = v;
+                }
+            }
+            emitPerfEvent("PDF_ENGINE_NODE_PERF_TOTAL", {
+                reqId,
+                phases: JSON.stringify(phases),
+                extra: extra ? JSON.stringify(extra) : undefined
+            }, measurements);
+        }
+    };
+}
+
+module.exports = {
+    telemetryClient,
+    trackCustomEvent,
+    createPerfTracker,
+    emitPerfPhase,
+    PERF_LOG,
+    nowNs,
+    nsToMs
+};
+

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -517,15 +517,13 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
-"@puppeteer/browsers@2.13.1":
-  version "2.13.1"
-  resolved "https://registry.yarnpkg.com/@puppeteer/browsers/-/browsers-2.13.1.tgz#be1a50cc550ad1c9a8e6af7fd9e336b2f071311f"
-  integrity sha512-zmS4RTK9fbrc++WlAJhxYbfz3IjDeOmkK/CwwbLmk7ydfS9e2CiEeRJHEPvjDVElO/bwXbidwGA37Bsm6LzCnQ==
+"@puppeteer/browsers@3.0.3":
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/@puppeteer/browsers/-/browsers-3.0.3.tgz#61388895e2f3665b59491152d204b3d9096bddd6"
+  integrity sha512-v3YaiGpzUTgOZkHBFR0iZg58Vto25SqBQxfLUXDiofJccwVl6Mlr7BdLCS1NZgxikdeIHf936cxYWL9IZp3tow==
   dependencies:
     debug "^4.4.3"
-    extract-zip "^2.0.1"
     progress "^2.0.3"
-    proxy-agent "^6.5.0"
     semver "^7.7.4"
     tar-fs "^3.1.1"
     yargs "^17.7.2"
@@ -548,11 +546,6 @@
   integrity sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==
   dependencies:
     "@sinonjs/commons" "^3.0.0"
-
-"@tootallnate/quickjs-emscripten@^0.23.0":
-  version "0.23.0"
-  resolved "https://registry.yarnpkg.com/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz#db4ecfd499a9765ab24002c3b696d02e6d32a12c"
-  integrity sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==
 
 "@types/babel__core@^7.1.14":
   version "7.20.5"
@@ -650,13 +643,6 @@
   dependencies:
     "@types/yargs-parser" "*"
 
-"@types/yauzl@^2.9.1":
-  version "2.10.3"
-  resolved "https://registry.yarnpkg.com/@types/yauzl/-/yauzl-2.10.3.tgz#e9b2808b4f109504a03cda958259876f61017999"
-  integrity sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==
-  dependencies:
-    "@types/node" "*"
-
 accepts@~1.3.8:
   version "1.3.8"
   resolved "https://registry.yarnpkg.com/accepts/-/accepts-1.3.8.tgz#0bf0be125b67014adcb0b0921e62db7bffe16b2e"
@@ -669,11 +655,6 @@ adm-zip@^0.5.10:
   version "0.5.17"
   resolved "https://registry.yarnpkg.com/adm-zip/-/adm-zip-0.5.17.tgz#5c0b65f37aeec5c2a94995c024f931f62e4bbc5a"
   integrity sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==
-
-agent-base@^7.1.0, agent-base@^7.1.2:
-  version "7.1.4"
-  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-7.1.4.tgz#e3cd76d4c548ee895d3c3fd8dc1f6c5b9032e7a8"
-  integrity sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==
 
 ansi-escapes@^4.2.1:
   version "4.3.2"
@@ -738,13 +719,6 @@ array-flatten@1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/array-flatten/-/array-flatten-1.1.1.tgz#9a5f699051b1e7073328f2a008968b64ea2955d2"
   integrity sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==
-
-ast-types@^0.13.4:
-  version "0.13.4"
-  resolved "https://registry.yarnpkg.com/ast-types/-/ast-types-0.13.4.tgz#ee0d77b343263965ecc3fb62da16e7222b2b6782"
-  integrity sha512-x1FCFnFifvYDDzTaLII71vG5uvDwgtmDTEVWAxrgeiR8VjMONcCXJx7E+USjDtHlwFmt9MysbqgF9b9Vjr6w+w==
-  dependencies:
-    tslib "^2.0.1"
 
 async-hook-jl@^1.7.6:
   version "1.7.6"
@@ -901,11 +875,6 @@ baseline-browser-mapping@^2.10.12:
   resolved "https://registry.yarnpkg.com/baseline-browser-mapping/-/baseline-browser-mapping-2.10.27.tgz#fee941c2a0b42cdf83c6427e4c830b1d0bdab2c3"
   integrity sha512-zEs/ufmZoUd7WftKpKyXaT6RFxpQ5Qm9xytKRHvJfxFV9DFJkZph9RvJ1LcOUi0Z1ZVijMte65JbILeV+8QQEA==
 
-basic-ftp@^5.0.2:
-  version "5.3.1"
-  resolved "https://registry.yarnpkg.com/basic-ftp/-/basic-ftp-5.3.1.tgz#3148ee9af43c0522514a4f973fecb1d3cbb6d71e"
-  integrity sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==
-
 binary-extensions@^2.0.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/binary-extensions/-/binary-extensions-2.3.0.tgz#f6e14a97858d327252200242d4ccfe522c445522"
@@ -968,11 +937,6 @@ bser@2.1.1:
   integrity sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==
   dependencies:
     node-int64 "^0.4.0"
-
-buffer-crc32@~0.2.3:
-  version "0.2.13"
-  resolved "https://registry.yarnpkg.com/buffer-crc32/-/buffer-crc32-0.2.13.tgz#0d333e3f00eac50aa1454abd30ef8c2a5d9a7242"
-  integrity sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==
 
 buffer-from@^1.0.0:
   version "1.1.2"
@@ -1060,10 +1024,10 @@ chokidar@^3.5.2:
   optionalDependencies:
     fsevents "~2.3.2"
 
-chromium-bidi@14.0.0:
-  version "14.0.0"
-  resolved "https://registry.yarnpkg.com/chromium-bidi/-/chromium-bidi-14.0.0.tgz#15a12ab083ae519a49a724e94994ca0a9ced9c8e"
-  integrity sha512-9gYlLtS6tStdRWzrtXaTMnqcM4dudNegMXJxkR0I/CXObHalYeYcAMPrL19eroNZHtJ8DQmu1E+ZNOYu/IXMXw==
+chromium-bidi@16.0.1:
+  version "16.0.1"
+  resolved "https://registry.yarnpkg.com/chromium-bidi/-/chromium-bidi-16.0.1.tgz#0c6b0e55065468fc777d62032b63b73f614b1d88"
+  integrity sha512-J63PGu/9PpeCwLIcKYyzWP6yaVL5pxuBc0shlYCYM8BaAkmlwiQboXO1iNbOgSDbVklEyYFfNEcHD8oOAWacUA==
   dependencies:
     mitt "^3.0.1"
     zod "^3.24.1"
@@ -1212,11 +1176,6 @@ cross-spawn@^7.0.3:
     shebang-command "^2.0.0"
     which "^2.0.1"
 
-data-uri-to-buffer@^6.0.2:
-  version "6.0.2"
-  resolved "https://registry.yarnpkg.com/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz#8a58bb67384b261a38ef18bea1810cb01badd28b"
-  integrity sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==
-
 debug@2.6.9:
   version "2.6.9"
   resolved "https://registry.yarnpkg.com/debug/-/debug-2.6.9.tgz#5d128515df134ff327e90a4c93f4e077a536341f"
@@ -1224,7 +1183,7 @@ debug@2.6.9:
   dependencies:
     ms "2.0.0"
 
-debug@4, debug@^4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.4, debug@^4.4.3:
+debug@^4, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.4.3:
   version "4.4.3"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.3.tgz#c6ae432d9bd9662582fce08709b038c58e9e3d6a"
   integrity sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==
@@ -1240,15 +1199,6 @@ deepmerge@^4.2.2:
   version "4.3.1"
   resolved "https://registry.yarnpkg.com/deepmerge/-/deepmerge-4.3.1.tgz#44b5f2147cd3b00d4b56137685966f26fd25dd4a"
   integrity sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==
-
-degenerator@^5.0.0:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/degenerator/-/degenerator-5.0.1.tgz#9403bf297c6dad9a1ece409b37db27954f91f2f5"
-  integrity sha512-TllpMR/t0M5sqCXfj85i4XaAzxmS5tVA16dqvdkMwGmzI+dXLXnw3J+3Vdv7VKw+ThlTMboK6i9rnZ6Nntj5CQ==
-  dependencies:
-    ast-types "^0.13.4"
-    escodegen "^2.1.0"
-    esprima "^4.0.1"
 
 delayed-stream@~1.0.0:
   version "1.0.0"
@@ -1394,31 +1344,10 @@ escape-string-regexp@^2.0.0:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz#a30304e99daa32e23b2fd20f51babd07cffca344"
   integrity sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==
 
-escodegen@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-2.1.0.tgz#ba93bbb7a43986d29d6041f99f5262da773e2e17"
-  integrity sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==
-  dependencies:
-    esprima "^4.0.1"
-    estraverse "^5.2.0"
-    esutils "^2.0.2"
-  optionalDependencies:
-    source-map "~0.6.1"
-
-esprima@^4.0.0, esprima@^4.0.1:
+esprima@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
   integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
-
-estraverse@^5.2.0:
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-5.3.0.tgz#2eea5290702f26ab8fe5370370ff86c965d21123"
-  integrity sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==
-
-esutils@^2.0.2:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
-  integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
 
 etag@~1.8.1:
   version "1.8.1"
@@ -1500,17 +1429,6 @@ express@^4.18.2:
     utils-merge "1.0.1"
     vary "~1.1.2"
 
-extract-zip@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/extract-zip/-/extract-zip-2.0.1.tgz#663dca56fe46df890d5f131ef4a06d22bb8ba13a"
-  integrity sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==
-  dependencies:
-    debug "^4.1.1"
-    get-stream "^5.1.0"
-    yauzl "^2.10.0"
-  optionalDependencies:
-    "@types/yauzl" "^2.9.1"
-
 fast-fifo@^1.2.0, fast-fifo@^1.3.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/fast-fifo/-/fast-fifo-1.3.2.tgz#286e31de96eb96d38a97899815740ba2a4f3640c"
@@ -1527,13 +1445,6 @@ fb-watchman@^2.0.0:
   integrity sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==
   dependencies:
     bser "2.1.1"
-
-fd-slicer@~1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/fd-slicer/-/fd-slicer-1.1.0.tgz#25c7c89cb1f9077f8891bbe61d8f390eae256f1e"
-  integrity sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==
-  dependencies:
-    pend "~1.2.0"
 
 fill-range@^7.1.1:
   version "7.1.1"
@@ -1652,26 +1563,10 @@ get-proto@^1.0.1:
     dunder-proto "^1.0.1"
     es-object-atoms "^1.0.0"
 
-get-stream@^5.1.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-5.2.0.tgz#4966a1795ee5ace65e706c4b7beb71257d6e22d3"
-  integrity sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==
-  dependencies:
-    pump "^3.0.0"
-
 get-stream@^6.0.0:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-6.0.1.tgz#a262d8eef67aced57c2852ad6167526a43cbf7b7"
   integrity sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==
-
-get-uri@^6.0.1:
-  version "6.0.5"
-  resolved "https://registry.yarnpkg.com/get-uri/-/get-uri-6.0.5.tgz#714892aa4a871db671abc5395e5e9447bc306a16"
-  integrity sha512-b1O07XYq8eRuVzBNgJLstU6FYc1tS6wnMtF1I1D9lE8LxZSOGZ7LhxN54yPP6mGw5f2CkXY2BQUL9Fx41qvcIg==
-  dependencies:
-    basic-ftp "^5.0.2"
-    data-uri-to-buffer "^6.0.2"
-    debug "^4.3.4"
 
 glob-parent@~5.1.2:
   version "5.1.2"
@@ -1769,22 +1664,6 @@ http-errors@~2.0.0, http-errors@~2.0.1:
     statuses "~2.0.2"
     toidentifier "~1.0.1"
 
-http-proxy-agent@^7.0.0, http-proxy-agent@^7.0.1:
-  version "7.0.2"
-  resolved "https://registry.yarnpkg.com/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz#9a8b1f246866c028509486585f62b8f2c18c270e"
-  integrity sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==
-  dependencies:
-    agent-base "^7.1.0"
-    debug "^4.3.4"
-
-https-proxy-agent@^7.0.6:
-  version "7.0.6"
-  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz#da8dfeac7da130b05c2ba4b59c9b6cd66611a6b9"
-  integrity sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==
-  dependencies:
-    agent-base "^7.1.2"
-    debug "4"
-
 human-signals@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-2.1.0.tgz#dc91fcba42e4d06e4abaed33b3e7a3c02f514ea0"
@@ -1847,11 +1726,6 @@ intl@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/intl/-/intl-1.2.5.tgz#82244a2190c4e419f8371f5aa34daa3420e2abde"
   integrity sha512-rK0KcPHeBFBcqsErKSpvZnrOmWOj+EmDkyJ57e90YWaQNqbcivcqmKDlHEeNprDWOsKzPsh1BfSpPQdDvclHVw==
-
-ip-address@^10.1.1:
-  version "10.2.0"
-  resolved "https://registry.yarnpkg.com/ip-address/-/ip-address-10.2.0.tgz#805fc178b20c518bd4c8548b24fe30892d7f3206"
-  integrity sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==
 
 ipaddr.js@1.9.1:
   version "1.9.1"
@@ -2403,11 +2277,6 @@ lru-cache@^5.1.1:
   dependencies:
     yallist "^3.0.2"
 
-lru-cache@^7.14.1:
-  version "7.18.3"
-  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-7.18.3.tgz#f793896e0fd0e954a59dfdd82f0773808df6aa89"
-  integrity sha512-jumlc0BIUrS3qJGgIkWZsyfAM7NCWiBcCDhnd+3NNM5KbBmLTgHVfWBcg6W+rLUsIpzpERPsvwUP7CckAQSOoA==
-
 make-dir@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-4.0.0.tgz#c3c2307a771277cd9638305f915c29ae741b614e"
@@ -2546,11 +2415,6 @@ neo-async@^2.6.2:
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
   integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
 
-netmask@^2.0.2:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/netmask/-/netmask-2.1.1.tgz#80043d265b53aa521b3bd01e8fcdf353f9e1e81e"
-  integrity sha512-eonl3sLUha+S1GzTPxychyhnUzKyeQkZ7jLjKrBagJgPla13F+uQ71HgpFefyHgqrjEbCPkDArxYsjY8/+gLKA==
-
 node-int64@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/node-int64/-/node-int64-0.4.0.tgz#87a9065cdb355d3182d8f94ce11188b825c68a3b"
@@ -2646,28 +2510,6 @@ p-try@^2.0.0:
   resolved "https://registry.yarnpkg.com/p-try/-/p-try-2.2.0.tgz#cb2868540e313d61de58fafbe35ce9004d5540e6"
   integrity sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
 
-pac-proxy-agent@^7.1.0:
-  version "7.2.0"
-  resolved "https://registry.yarnpkg.com/pac-proxy-agent/-/pac-proxy-agent-7.2.0.tgz#9cfaf33ff25da36f6147a20844230ec92c06e5df"
-  integrity sha512-TEB8ESquiLMc0lV8vcd5Ql/JAKAoyzHFXaStwjkzpOpC5Yv+pIzLfHvjTSdf3vpa2bMiUQrg9i6276yn8666aA==
-  dependencies:
-    "@tootallnate/quickjs-emscripten" "^0.23.0"
-    agent-base "^7.1.2"
-    debug "^4.3.4"
-    get-uri "^6.0.1"
-    http-proxy-agent "^7.0.0"
-    https-proxy-agent "^7.0.6"
-    pac-resolver "^7.0.1"
-    socks-proxy-agent "^8.0.5"
-
-pac-resolver@^7.0.1:
-  version "7.0.1"
-  resolved "https://registry.yarnpkg.com/pac-resolver/-/pac-resolver-7.0.1.tgz#54675558ea368b64d210fd9c92a640b5f3b8abb6"
-  integrity sha512-5NPgf87AT2STgwa2ntRMr45jTKrYBGkVU36yT0ig/n/GMAa3oPqhZfIQ2kMEimReg0+t9kZViDVZ83qfVUlckg==
-  dependencies:
-    degenerator "^5.0.0"
-    netmask "^2.0.2"
-
 parent-module@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/parent-module/-/parent-module-1.0.1.tgz#691d2709e78c79fae3a156622452d00762caaaa2"
@@ -2714,11 +2556,6 @@ path-to-regexp@~0.1.12:
   version "0.1.13"
   resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-0.1.13.tgz#9b22ec16bc3ab88d05a0c7e369869421401ab17d"
   integrity sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==
-
-pend@~1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/pend/-/pend-1.2.0.tgz#7a57eb550a6783f9115331fcf4663d5c8e007a50"
-  integrity sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==
 
 picocolors@^1.1.1:
   version "1.1.1"
@@ -2777,25 +2614,6 @@ proxy-addr@~2.0.7:
     forwarded "0.2.0"
     ipaddr.js "1.9.1"
 
-proxy-agent@^6.5.0:
-  version "6.5.0"
-  resolved "https://registry.yarnpkg.com/proxy-agent/-/proxy-agent-6.5.0.tgz#9e49acba8e4ee234aacb539f89ed9c23d02f232d"
-  integrity sha512-TmatMXdr2KlRiA2CyDu8GqR8EjahTG3aY3nXjdzFyoZbmB8hrBsTyMezhULIXKnC0jpfjlmiZ3+EaCzoInSu/A==
-  dependencies:
-    agent-base "^7.1.2"
-    debug "^4.3.4"
-    http-proxy-agent "^7.0.1"
-    https-proxy-agent "^7.0.6"
-    lru-cache "^7.14.1"
-    pac-proxy-agent "^7.1.0"
-    proxy-from-env "^1.1.0"
-    socks-proxy-agent "^8.0.5"
-
-proxy-from-env@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-1.1.0.tgz#e102f16ca355424865755d2c9e8ea4f24d58c3e2"
-  integrity sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==
-
 proxy-from-env@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/proxy-from-env/-/proxy-from-env-2.1.0.tgz#a7487568adad577cfaaa7e88c49cab3ab3081aba"
@@ -2814,29 +2632,29 @@ pump@^3.0.0:
     end-of-stream "^1.1.0"
     once "^1.3.1"
 
-puppeteer-core@24.43.0:
-  version "24.43.0"
-  resolved "https://registry.yarnpkg.com/puppeteer-core/-/puppeteer-core-24.43.0.tgz#8a2fe71c3a02ac9b43d055b884f0906581707431"
-  integrity sha512-cCRNXsUlhyPoKDz6+TiSpfZpRS3mD6Y1YFKhkdr6ik6TMfuJb7fAtXq9ThUFc4sphxObDk3BuAvdxc1Y6YOnqQ==
+puppeteer-core@25.0.4:
+  version "25.0.4"
+  resolved "https://registry.yarnpkg.com/puppeteer-core/-/puppeteer-core-25.0.4.tgz#35c9e421ce71651dfc85d381eb5fdb5e72279df5"
+  integrity sha512-K1LQKDP6w1rIr1jUyN9obH16TO/DCy86k3q+FBd2prGY+TStxhFySxmaZZuRF+0D3BJXjwCYFke7tMHCH4olTA==
   dependencies:
-    "@puppeteer/browsers" "2.13.1"
-    chromium-bidi "14.0.0"
+    "@puppeteer/browsers" "3.0.3"
+    chromium-bidi "16.0.1"
     debug "^4.4.3"
     devtools-protocol "0.0.1608973"
     typed-query-selector "^2.12.2"
     webdriver-bidi-protocol "0.4.1"
     ws "^8.20.0"
 
-puppeteer@^24.42.0:
-  version "24.43.0"
-  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-24.43.0.tgz#98b4a0bc36bcc53c2c9d6afb80d0464b26d5cdf7"
-  integrity sha512-DRnMFz+J3s4lFUQcjqKl0/7h0jzlCZuUFU9lNjtKrnMl5WI1RwCaIItpHVu9empuPyUreYueN0sUW3/pnfdqsg==
+puppeteer@25.0.4:
+  version "25.0.4"
+  resolved "https://registry.yarnpkg.com/puppeteer/-/puppeteer-25.0.4.tgz#c149dc345a64753162816ffe68eac9eef7e78064"
+  integrity sha512-QFdBAuNOqL0I+AdARTlRR1KcgPk0fo0dU127e1ZQFVxb9QPcpBDIiQp/dMgdbyLXHpF2GRjC/OezDmjKcLCKYw==
   dependencies:
-    "@puppeteer/browsers" "2.13.1"
-    chromium-bidi "14.0.0"
+    "@puppeteer/browsers" "3.0.3"
+    chromium-bidi "16.0.1"
     cosmiconfig "^9.0.0"
     devtools-protocol "0.0.1608973"
-    puppeteer-core "24.43.0"
+    puppeteer-core "25.0.4"
     typed-query-selector "^2.12.2"
 
 pure-rand@^6.0.0:
@@ -3088,28 +2906,6 @@ slash@^3.0.0:
   resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
   integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
 
-smart-buffer@^4.2.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/smart-buffer/-/smart-buffer-4.2.0.tgz#6e1d71fa4f18c05f7d0ff216dd16a481d0e8d9ae"
-  integrity sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg==
-
-socks-proxy-agent@^8.0.5:
-  version "8.0.5"
-  resolved "https://registry.yarnpkg.com/socks-proxy-agent/-/socks-proxy-agent-8.0.5.tgz#b9cdb4e7e998509d7659d689ce7697ac21645bee"
-  integrity sha512-HehCEsotFqbPW9sJ8WVYB6UbmIMv7kUUORIF2Nncq4VQvBfNBLibW9YZR5dlYCSUhwcD628pRllm7n+E+YTzJw==
-  dependencies:
-    agent-base "^7.1.2"
-    debug "^4.3.4"
-    socks "^2.8.3"
-
-socks@^2.8.3:
-  version "2.8.8"
-  resolved "https://registry.yarnpkg.com/socks/-/socks-2.8.8.tgz#23bef6d02748eac847ad75610deb6c472554c67a"
-  integrity sha512-NlGELfPrgX2f1TAAcz0WawlLn+0r3FyhhCRpFFK2CemXenPYvzMWWZINv3eDNo9ucdwme7oCHRY0Jnbs4aIkog==
-  dependencies:
-    ip-address "^10.1.1"
-    smart-buffer "^4.2.0"
-
 source-map-support@0.5.13:
   version "0.5.13"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.13.tgz#31b24a9c2e73c2de85066c0feb7d44767ed52932"
@@ -3118,7 +2914,7 @@ source-map-support@0.5.13:
     buffer-from "^1.0.0"
     source-map "^0.6.0"
 
-source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.1:
+source-map@^0.6.0, source-map@^0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
@@ -3297,11 +3093,6 @@ touch@^3.1.0:
   resolved "https://registry.yarnpkg.com/touch/-/touch-3.1.1.tgz#097a23d7b161476435e5c1344a95c0f75b4a5694"
   integrity sha512-r0eojU4bI8MnHr8c5bNo7lJDdI2qXlWWJk6a9EAFG7vbhTjElYhBVS3/miuE0uOuoLdb8Mc/rVfsmm6eo5o9GA==
 
-tslib@^2.0.1:
-  version "2.8.1"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
-  integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
-
 type-detect@4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
@@ -3475,14 +3266,6 @@ yargs@^17.3.1, yargs@^17.7.2:
     string-width "^4.2.3"
     y18n "^5.0.5"
     yargs-parser "^21.1.1"
-
-yauzl@^2.10.0:
-  version "2.10.0"
-  resolved "https://registry.yarnpkg.com/yauzl/-/yauzl-2.10.0.tgz#c7eb17c93e112cb1086fa6d8e51fb0667b79a5f9"
-  integrity sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==
-  dependencies:
-    buffer-crc32 "~0.2.3"
-    fd-slicer "~1.1.0"
 
 yocto-queue@^0.1.0:
   version "0.1.0"

--- a/openapi/openapi-node-monitor.json
+++ b/openapi/openapi-node-monitor.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.1",
   "info": {
     "title": "PDF Engine Node - Unified Monitoring (Shared & PrintIT)",
-    "version": "2.10.29-4-PIDM-1954-improve-performance-app-node"
+    "version": "2.10.29-5-PIDM-1954-improve-performance-app-node"
   },
   "servers": [
     {

--- a/openapi/openapi-node-monitor.json
+++ b/openapi/openapi-node-monitor.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.1",
   "info": {
     "title": "PDF Engine Node - Unified Monitoring (Shared & PrintIT)",
-    "version": "2.10.29-1-PIDM-1904-upgrade-to-node-24-lts"
+    "version": "2.10.29-2-PIDM-1954-improve-performance-app-node"
   },
   "servers": [
     {

--- a/openapi/openapi-node-monitor.json
+++ b/openapi/openapi-node-monitor.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.1",
   "info": {
     "title": "PDF Engine Node - Unified Monitoring (Shared & PrintIT)",
-    "version": "2.10.29-3-PIDM-1954-improve-performance-app-node"
+    "version": "2.10.29-4-PIDM-1954-improve-performance-app-node"
   },
   "servers": [
     {

--- a/openapi/openapi-node-monitor.json
+++ b/openapi/openapi-node-monitor.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.1",
   "info": {
     "title": "PDF Engine Node - Unified Monitoring (Shared & PrintIT)",
-    "version": "2.10.29-6-PIDM-1954-improve-performance-app-node"
+    "version": "2.10.29-7-PIDM-1954-improve-performance-app-node"
   },
   "servers": [
     {

--- a/openapi/openapi-node-monitor.json
+++ b/openapi/openapi-node-monitor.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.1",
   "info": {
     "title": "PDF Engine Node - Unified Monitoring (Shared & PrintIT)",
-    "version": "2.10.29-5-PIDM-1954-improve-performance-app-node"
+    "version": "2.10.29-6-PIDM-1954-improve-performance-app-node"
   },
   "servers": [
     {

--- a/openapi/openapi-node-monitor.json
+++ b/openapi/openapi-node-monitor.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.1",
   "info": {
     "title": "PDF Engine Node - Unified Monitoring (Shared & PrintIT)",
-    "version": "2.10.29-7-PIDM-1954-improve-performance-app-node"
+    "version": "2.10.29-8-PIDM-1954-improve-performance-app-node"
   },
   "servers": [
     {

--- a/openapi/openapi-node-monitor.json
+++ b/openapi/openapi-node-monitor.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.1",
   "info": {
     "title": "PDF Engine Node - Unified Monitoring (Shared & PrintIT)",
-    "version": "2.10.29-2-PIDM-1954-improve-performance-app-node"
+    "version": "2.10.29-3-PIDM-1954-improve-performance-app-node"
   },
   "servers": [
     {

--- a/openapi/openapi-pdf-engine-monitor.json
+++ b/openapi/openapi-pdf-engine-monitor.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.1",
   "info": {
     "title": "PDF Engine - Unified Monitoring (Shared & PrintIT)",
-    "version": "2.10.29-6-PIDM-1954-improve-performance-app-node"
+    "version": "2.10.29-7-PIDM-1954-improve-performance-app-node"
   },
   "servers": [
     {

--- a/openapi/openapi-pdf-engine-monitor.json
+++ b/openapi/openapi-pdf-engine-monitor.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.1",
   "info": {
     "title": "PDF Engine - Unified Monitoring (Shared & PrintIT)",
-    "version": "2.10.29-5-PIDM-1954-improve-performance-app-node"
+    "version": "2.10.29-6-PIDM-1954-improve-performance-app-node"
   },
   "servers": [
     {

--- a/openapi/openapi-pdf-engine-monitor.json
+++ b/openapi/openapi-pdf-engine-monitor.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.1",
   "info": {
     "title": "PDF Engine - Unified Monitoring (Shared & PrintIT)",
-    "version": "2.10.29-2-PIDM-1954-improve-performance-app-node"
+    "version": "2.10.29-3-PIDM-1954-improve-performance-app-node"
   },
   "servers": [
     {

--- a/openapi/openapi-pdf-engine-monitor.json
+++ b/openapi/openapi-pdf-engine-monitor.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.1",
   "info": {
     "title": "PDF Engine - Unified Monitoring (Shared & PrintIT)",
-    "version": "2.10.29-1-PIDM-1904-upgrade-to-node-24-lts"
+    "version": "2.10.29-2-PIDM-1954-improve-performance-app-node"
   },
   "servers": [
     {

--- a/openapi/openapi-pdf-engine-monitor.json
+++ b/openapi/openapi-pdf-engine-monitor.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.1",
   "info": {
     "title": "PDF Engine - Unified Monitoring (Shared & PrintIT)",
-    "version": "2.10.29-7-PIDM-1954-improve-performance-app-node"
+    "version": "2.10.29-8-PIDM-1954-improve-performance-app-node"
   },
   "servers": [
     {

--- a/openapi/openapi-pdf-engine-monitor.json
+++ b/openapi/openapi-pdf-engine-monitor.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.1",
   "info": {
     "title": "PDF Engine - Unified Monitoring (Shared & PrintIT)",
-    "version": "2.10.29-4-PIDM-1954-improve-performance-app-node"
+    "version": "2.10.29-5-PIDM-1954-improve-performance-app-node"
   },
   "servers": [
     {

--- a/openapi/openapi-pdf-engine-monitor.json
+++ b/openapi/openapi-pdf-engine-monitor.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.1",
   "info": {
     "title": "PDF Engine - Unified Monitoring (Shared & PrintIT)",
-    "version": "2.10.29-3-PIDM-1954-improve-performance-app-node"
+    "version": "2.10.29-4-PIDM-1954-improve-performance-app-node"
   },
   "servers": [
     {

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.1",
   "info": {
     "title": "OpenAPI definition - PDF Engine",
-    "version": "2.10.29-1-PIDM-1904-upgrade-to-node-24-lts"
+    "version": "2.10.29-2-PIDM-1954-improve-performance-app-node"
   },
   "servers": [
     {

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.1",
   "info": {
     "title": "OpenAPI definition - PDF Engine",
-    "version": "2.10.29-6-PIDM-1954-improve-performance-app-node"
+    "version": "2.10.29-7-PIDM-1954-improve-performance-app-node"
   },
   "servers": [
     {

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.1",
   "info": {
     "title": "OpenAPI definition - PDF Engine",
-    "version": "2.10.29-3-PIDM-1954-improve-performance-app-node"
+    "version": "2.10.29-4-PIDM-1954-improve-performance-app-node"
   },
   "servers": [
     {

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.1",
   "info": {
     "title": "OpenAPI definition - PDF Engine",
-    "version": "2.10.29-5-PIDM-1954-improve-performance-app-node"
+    "version": "2.10.29-6-PIDM-1954-improve-performance-app-node"
   },
   "servers": [
     {

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.1",
   "info": {
     "title": "OpenAPI definition - PDF Engine",
-    "version": "2.10.29-4-PIDM-1954-improve-performance-app-node"
+    "version": "2.10.29-5-PIDM-1954-improve-performance-app-node"
   },
   "servers": [
     {

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.1",
   "info": {
     "title": "OpenAPI definition - PDF Engine",
-    "version": "2.10.29-7-PIDM-1954-improve-performance-app-node"
+    "version": "2.10.29-8-PIDM-1954-improve-performance-app-node"
   },
   "servers": [
     {

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.1",
   "info": {
     "title": "OpenAPI definition - PDF Engine",
-    "version": "2.10.29-2-PIDM-1954-improve-performance-app-node"
+    "version": "2.10.29-3-PIDM-1954-improve-performance-app-node"
   },
   "servers": [
     {

--- a/openapi/openapi_node.json
+++ b/openapi/openapi_node.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.1",
   "info": {
     "title": "OpenAPI definition - PDF Engine Node",
-    "version": "2.10.29-7-PIDM-1954-improve-performance-app-node"
+    "version": "2.10.29-8-PIDM-1954-improve-performance-app-node"
   },
   "servers": [
     {

--- a/openapi/openapi_node.json
+++ b/openapi/openapi_node.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.1",
   "info": {
     "title": "OpenAPI definition - PDF Engine Node",
-    "version": "2.10.29-2-PIDM-1954-improve-performance-app-node"
+    "version": "2.10.29-3-PIDM-1954-improve-performance-app-node"
   },
   "servers": [
     {

--- a/openapi/openapi_node.json
+++ b/openapi/openapi_node.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.1",
   "info": {
     "title": "OpenAPI definition - PDF Engine Node",
-    "version": "2.10.29-3-PIDM-1954-improve-performance-app-node"
+    "version": "2.10.29-4-PIDM-1954-improve-performance-app-node"
   },
   "servers": [
     {

--- a/openapi/openapi_node.json
+++ b/openapi/openapi_node.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.1",
   "info": {
     "title": "OpenAPI definition - PDF Engine Node",
-    "version": "2.10.29-5-PIDM-1954-improve-performance-app-node"
+    "version": "2.10.29-6-PIDM-1954-improve-performance-app-node"
   },
   "servers": [
     {

--- a/openapi/openapi_node.json
+++ b/openapi/openapi_node.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.1",
   "info": {
     "title": "OpenAPI definition - PDF Engine Node",
-    "version": "2.10.29-6-PIDM-1954-improve-performance-app-node"
+    "version": "2.10.29-7-PIDM-1954-improve-performance-app-node"
   },
   "servers": [
     {

--- a/openapi/openapi_node.json
+++ b/openapi/openapi_node.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.1",
   "info": {
     "title": "OpenAPI definition - PDF Engine Node",
-    "version": "2.10.29-1-PIDM-1904-upgrade-to-node-24-lts"
+    "version": "2.10.29-2-PIDM-1954-improve-performance-app-node"
   },
   "servers": [
     {

--- a/openapi/openapi_node.json
+++ b/openapi/openapi_node.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.1",
   "info": {
     "title": "OpenAPI definition - PDF Engine Node",
-    "version": "2.10.29-4-PIDM-1954-improve-performance-app-node"
+    "version": "2.10.29-5-PIDM-1954-improve-performance-app-node"
   },
   "servers": [
     {

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>it.gov.pagopa</groupId>
     <artifactId>pdf-engine</artifactId>
-    <version>2.10.29-7-PIDM-1954-improve-performance-app-node</version>
+    <version>2.10.29-8-PIDM-1954-improve-performance-app-node</version>
     <packaging>jar</packaging>
 
     <name>pagopa-pdf-engine</name>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>it.gov.pagopa</groupId>
     <artifactId>pdf-engine</artifactId>
-    <version>2.10.29-3-PIDM-1954-improve-performance-app-node</version>
+    <version>2.10.29-4-PIDM-1954-improve-performance-app-node</version>
     <packaging>jar</packaging>
 
     <name>pagopa-pdf-engine</name>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>it.gov.pagopa</groupId>
     <artifactId>pdf-engine</artifactId>
-    <version>2.10.29-4-PIDM-1954-improve-performance-app-node</version>
+    <version>2.10.29-5-PIDM-1954-improve-performance-app-node</version>
     <packaging>jar</packaging>
 
     <name>pagopa-pdf-engine</name>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>it.gov.pagopa</groupId>
     <artifactId>pdf-engine</artifactId>
-    <version>2.10.29-2-PIDM-1954-improve-performance-app-node</version>
+    <version>2.10.29-3-PIDM-1954-improve-performance-app-node</version>
     <packaging>jar</packaging>
 
     <name>pagopa-pdf-engine</name>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>it.gov.pagopa</groupId>
     <artifactId>pdf-engine</artifactId>
-    <version>2.10.29-1-PIDM-1904-upgrade-to-node-24-lts</version>
+    <version>2.10.29-2-PIDM-1954-improve-performance-app-node</version>
     <packaging>jar</packaging>
 
     <name>pagopa-pdf-engine</name>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>it.gov.pagopa</groupId>
     <artifactId>pdf-engine</artifactId>
-    <version>2.10.29-6-PIDM-1954-improve-performance-app-node</version>
+    <version>2.10.29-7-PIDM-1954-improve-performance-app-node</version>
     <packaging>jar</packaging>
 
     <name>pagopa-pdf-engine</name>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>it.gov.pagopa</groupId>
     <artifactId>pdf-engine</artifactId>
-    <version>2.10.29-5-PIDM-1954-improve-performance-app-node</version>
+    <version>2.10.29-6-PIDM-1954-improve-performance-app-node</version>
     <packaging>jar</packaging>
 
     <name>pagopa-pdf-engine</name>


### PR DESCRIPTION
#### List of Changes

- **Pinned Chrome to 127.0.6533.88** in the Node sidecar (`node/Dockerfile`): skip Puppeteer's auto-download (`PUPPETEER_SKIP_DOWNLOAD=true`), install the legacy browser via `@puppeteer/browsers`, and point Puppeteer to it through `PUPPETEER_EXECUTABLE_PATH`. The Chrome build is configurable via the `PINNED_CHROME_VERSION` build arg.
- **Handlebars template caching**: per-process LRU cache keyed on the SHA-1 of the template source (`TEMPLATE_CACHE_MAX=32`) to avoid recompiling the same template on every request.
- **Added performance instrumentation** Per-phase timings are emitted as App Insights `PDF_ENGINE_NODE` custom events (`type=PDF_ENGINE_NODE_PERF`). **Disabled by default**, enabled by setting `PERF_LOG=1`.
- **Documentation**: README rewritten to reflect the current Java function + Node sidecar architecture, Chrome pinning rationale and maintenance procedure, and the full env-var matrix for both processes.
- **Bump Puppeteer to 25.0.4**

#### Motivation and Context
[PIDM-1954 ](https://pagopa.atlassian.net/browse/PIDM-1954)

After the multilingual rollout (v2.10.29) and the Puppeteer/Node upgrades, throughput on the k6 reference scenario (`constant-arrival-rate`, 50 req/s, 3 min) had dropped from the v2.10.23 baseline of **~4.94 req/s** to **~3.72 req/s**. Bisecting Puppeteer + Chrome combinations showed that the regression lives in the Chromium PDF pipeline shipped with Puppeteer 24+ (Chrome ≥132).

Pinning Chrome to 127 restores the baseline without rolling back any of the multilingual / Node 24 work. 

#### How Has This Been Tested?

- **Unit tests**: `yarn test` (Node sidecar) — all green.
- **Integration test**: Executed throught `pagopa-print-payment-notice-service`
- **Performance tests**: same k6 scenario (`performance-test/src/test-types/constant.json`, 50 req/s, 3 min, maxVUs=100), executed against the deployed Java+Node pair on Azure App Service.

  | Branch / configuration | req/s (avg over 3 runs) |
  |---|---:|
  | `2.10.23` baseline (Puppeteer 22 + bundled Chrome) | 4.94 |
  | `2.10.29` multilingual (Puppeteer 24, default Chrome) | 3.73 |
  | `2.10.29` + Puppeteer 25, default Chrome | 3.52 |
  | **This branch (Puppeteer 25 + pinned Chrome 127)** | **5.00** ✅ |

#### Screenshots (if appropriate)

#### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue) — performance regression
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.